### PR TITLE
Split controller generator

### DIFF
--- a/.mps/modules.xml
+++ b/.mps/modules.xml
@@ -3,6 +3,7 @@
   <component name="MPSProject">
     <projectModules>
       <modulePath path="$PROJECT_DIR$/languages/Algorithm/Algorithm.mpl" folder="" />
+      <modulePath path="$PROJECT_DIR$/languages/Algorithm_CGenerator/Algorithm_CGenerator.mpl" folder="" />
       <modulePath path="$PROJECT_DIR$/solutions/Algorithm.build/Algorithm.build.msd" folder="" />
       <modulePath path="$PROJECT_DIR$/solutions/Algorithm.sandbox/Algorithm.sandbox.msd" folder="" />
     </projectModules>

--- a/build.xml
+++ b/build.xml
@@ -101,7 +101,6 @@
           <module ref="d7eb0a2a-bd50-4576-beae-e4a89db35f20(jetbrains.mps.lang.scopes.runtime)" kind="rt" />
           <module ref="31f56055-9d30-42b3-a2b1-fb3f554d7075(jetbrains.mps.lang.smodel.query.runtime)" kind="rt" />
           <module ref="9a4afe51-f114-4595-b5df-048ce3c596be(jetbrains.mps.runtime)" kind="rt" />
-          <module ref="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" kind="cl" />
           <module ref="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" kind="cl" />
           <module ref="5dae8159-ab99-46bb-a40d-0cee30ee7018(jetbrains.mps.lang.constraints.rules.kinds)" kind="cl" />
           <module ref="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" kind="cl" />

--- a/build.xml
+++ b/build.xml
@@ -70,7 +70,6 @@
         <name>algorithm</name>
         <version>1.0</version>
         <depends>jetbrains.mps.core</depends>
-        <depends>jetbrains.mps.build</depends>
         
         <extensions defaultExtensionNs="com.intellij">
           <mps.LanguageLibrary dir="/languages" />

--- a/languages/Algorithm/models/Algorithm.actions.mps
+++ b/languages/Algorithm/models/Algorithm.actions.mps
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:3477cf86-9f1c-4a93-a5bf-4780a031bff7(Algorithm.actions)">
+  <persistence version="9" />
+  <languages>
+    <use id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions" version="4" />
+    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
+  </languages>
+  <imports>
+    <import index="yvgz" ref="r:3b411c10-569a-4299-9505-176144359d3b(Algorithm.structure)" implicit="true" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions">
+      <concept id="1158700664498" name="jetbrains.mps.lang.actions.structure.NodeFactories" flags="ng" index="37WguZ">
+        <child id="1158700779049" name="nodeFactory" index="37WGs$" />
+      </concept>
+      <concept id="1158700725281" name="jetbrains.mps.lang.actions.structure.NodeFactory" flags="ig" index="37WvkG">
+        <reference id="1158700943156" name="applicableConcept" index="37XkoT" />
+        <child id="1158701448518" name="setupFunction" index="37ZfLb" />
+      </concept>
+      <concept id="1158701162220" name="jetbrains.mps.lang.actions.structure.NodeSetupFunction" flags="in" index="37Y9Zx" />
+      <concept id="5584396657084912703" name="jetbrains.mps.lang.actions.structure.NodeSetupFunction_NewNode" flags="nn" index="1r4Lsj" />
+      <concept id="5584396657084920670" name="jetbrains.mps.lang.actions.structure.NodeSetupFunction_EnclosingNode" flags="nn" index="1r4N1M" />
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
+        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
+      </concept>
+      <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
+        <child id="1177027386292" name="conceptArgument" index="cj9EA" />
+      </concept>
+      <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
+        <child id="1180636770616" name="createdType" index="3zrR0E" />
+      </concept>
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
+        <reference id="1138056516764" name="link" index="3Tt5mk" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="37WguZ" id="7YqZU9FlRDu">
+    <property role="TrG5h" value="SchedulerDataPort" />
+    <node concept="37WvkG" id="7YqZU9FlRDv" role="37WGs$">
+      <ref role="37XkoT" to="yvgz:6po$YwiVCCi" resolve="DataPort" />
+      <node concept="37Y9Zx" id="7YqZU9FlRDw" role="37ZfLb">
+        <node concept="3clFbS" id="7YqZU9FlRDx" role="2VODD2">
+          <node concept="3clFbJ" id="7YqZU9FlRDG" role="3cqZAp">
+            <node concept="2OqwBi" id="7YqZU9FlS5g" role="3clFbw">
+              <node concept="1r4N1M" id="7YqZU9FlRE0" role="2Oq$k0" />
+              <node concept="1mIQ4w" id="7YqZU9FlSg8" role="2OqNvi">
+                <node concept="chp4Y" id="7YqZU9FlSi7" role="cj9EA">
+                  <ref role="cht4Q" to="yvgz:29RmJoXeePl" resolve="SchedulerBlock" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="7YqZU9FlRDI" role="3clFbx">
+              <node concept="3clFbF" id="7YqZU9FlSkB" role="3cqZAp">
+                <node concept="37vLTI" id="7YqZU9FlVtK" role="3clFbG">
+                  <node concept="2ShNRf" id="7YqZU9FlVyu" role="37vLTx">
+                    <node concept="3zrR0B" id="7YqZU9FlVys" role="2ShVmc">
+                      <node concept="3Tqbb2" id="7YqZU9FlVyt" role="3zrR0E">
+                        <ref role="ehGHo" to="tpee:f_0P_4Y" resolve="BooleanType" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="7YqZU9FlSte" role="37vLTJ">
+                    <node concept="1r4Lsj" id="7YqZU9FlSkA" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="7YqZU9FlSA6" role="2OqNvi">
+                      <ref role="3Tt5mk" to="yvgz:6po$YwiVDtx" resolve="type" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/languages/Algorithm/models/Algorithm.behavior.mps
+++ b/languages/Algorithm/models/Algorithm.behavior.mps
@@ -1152,6 +1152,113 @@
         <ref role="3uigEE" to="o8zo:3fifI_xCtN$" resolve="Scope" />
       </node>
     </node>
+    <node concept="13i0hz" id="44Cv2OMJP6B" role="13h7CS">
+      <property role="TrG5h" value="getAllDataBlockContainers" />
+      <node concept="3Tm1VV" id="44Cv2OMJP6C" role="1B3o_S" />
+      <node concept="2I9FWS" id="44Cv2OMJRzr" role="3clF45">
+        <ref role="2I9WkF" to="yvgz:5o1iPWxUm1h" resolve="DataBlockContainer" />
+      </node>
+      <node concept="3clFbS" id="44Cv2OMJP6E" role="3clF47">
+        <node concept="3cpWs8" id="44Cv2OMJR$n" role="3cqZAp">
+          <node concept="3cpWsn" id="44Cv2OMJR$q" role="3cpWs9">
+            <property role="TrG5h" value="dataBlocks" />
+            <node concept="2I9FWS" id="44Cv2OMJR$m" role="1tU5fm">
+              <ref role="2I9WkF" to="yvgz:5o1iPWxUm1h" resolve="DataBlockContainer" />
+            </node>
+            <node concept="2ShNRf" id="44Cv2OMJR_t" role="33vP2m">
+              <node concept="2T8Vx0" id="44Cv2OMJR_f" role="2ShVmc">
+                <node concept="2I9FWS" id="44Cv2OMJR_g" role="2T96Bj">
+                  <ref role="2I9WkF" to="yvgz:5o1iPWxUm1h" resolve="DataBlockContainer" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="44Cv2OMMLFz" role="3cqZAp">
+          <node concept="2OqwBi" id="44Cv2OMMO$C" role="3clFbG">
+            <node concept="37vLTw" id="44Cv2OMMLFx" role="2Oq$k0">
+              <ref role="3cqZAo" node="44Cv2OMJR$q" resolve="dataBlocks" />
+            </node>
+            <node concept="TSZUe" id="44Cv2OMMQTM" role="2OqNvi">
+              <node concept="13iPFW" id="44Cv2OMMR2p" role="25WWJ7" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="44Cv2OMJRAK" role="3cqZAp">
+          <node concept="2OqwBi" id="44Cv2OMJTNm" role="3clFbG">
+            <node concept="2OqwBi" id="44Cv2OMJRKS" role="2Oq$k0">
+              <node concept="13iPFW" id="44Cv2OMJRAI" role="2Oq$k0" />
+              <node concept="3Tsc0h" id="44Cv2OMJRXL" role="2OqNvi">
+                <ref role="3TtcxE" to="yvgz:5o1iPWxUm1i" resolve="data_blocks" />
+              </node>
+            </node>
+            <node concept="2es0OD" id="44Cv2OMJVN9" role="2OqNvi">
+              <node concept="1bVj0M" id="44Cv2OMJVNb" role="23t8la">
+                <node concept="3clFbS" id="44Cv2OMJVNc" role="1bW5cS">
+                  <node concept="3clFbJ" id="44Cv2OMJW0T" role="3cqZAp">
+                    <node concept="2OqwBi" id="44Cv2OMJWnw" role="3clFbw">
+                      <node concept="37vLTw" id="44Cv2OMJWaH" role="2Oq$k0">
+                        <ref role="3cqZAo" node="44Cv2OMJVNd" resolve="childBlock" />
+                      </node>
+                      <node concept="1mIQ4w" id="44Cv2OMJW$S" role="2OqNvi">
+                        <node concept="chp4Y" id="44Cv2OMJWDI" role="cj9EA">
+                          <ref role="cht4Q" to="yvgz:5o1iPWxUm1h" resolve="DataBlockContainer" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbS" id="44Cv2OMJW0V" role="3clFbx">
+                      <node concept="3cpWs8" id="44Cv2OMKRE4" role="3cqZAp">
+                        <node concept="3cpWsn" id="44Cv2OMKRE7" role="3cpWs9">
+                          <property role="TrG5h" value="childContainer" />
+                          <node concept="3Tqbb2" id="44Cv2OMKRE2" role="1tU5fm">
+                            <ref role="ehGHo" to="yvgz:5o1iPWxUm1h" resolve="DataBlockContainer" />
+                          </node>
+                          <node concept="1PxgMI" id="44Cv2OML24e" role="33vP2m">
+                            <property role="1BlNFB" value="true" />
+                            <node concept="chp4Y" id="44Cv2OML4e5" role="3oSUPX">
+                              <ref role="cht4Q" to="yvgz:5o1iPWxUm1h" resolve="DataBlockContainer" />
+                            </node>
+                            <node concept="37vLTw" id="44Cv2OML1J4" role="1m5AlR">
+                              <ref role="3cqZAo" node="44Cv2OMJVNd" resolve="childBlock" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="44Cv2OMJY$C" role="3cqZAp">
+                        <node concept="2OqwBi" id="44Cv2OMK0sL" role="3clFbG">
+                          <node concept="37vLTw" id="44Cv2OMJY$A" role="2Oq$k0">
+                            <ref role="3cqZAo" node="44Cv2OMJR$q" resolve="dataBlocks" />
+                          </node>
+                          <node concept="X8dFx" id="44Cv2OMK2Di" role="2OqNvi">
+                            <node concept="2OqwBi" id="44Cv2OMKcNu" role="25WWJ7">
+                              <node concept="2qgKlT" id="44Cv2OMKf1G" role="2OqNvi">
+                                <ref role="37wK5l" node="44Cv2OMJP6B" resolve="getAllDataBlockContainers" />
+                              </node>
+                              <node concept="37vLTw" id="44Cv2OMLvMS" role="2Oq$k0">
+                                <ref role="3cqZAo" node="44Cv2OMKRE7" resolve="childContainer" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="44Cv2OMJVNd" role="1bW2Oz">
+                  <property role="TrG5h" value="childBlock" />
+                  <node concept="2jxLKc" id="44Cv2OMJVNe" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="44Cv2OMJRA4" role="3cqZAp">
+          <node concept="37vLTw" id="44Cv2OMJRA2" role="3clFbG">
+            <ref role="3cqZAo" node="44Cv2OMJR$q" resolve="dataBlocks" />
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
 </model>
 

--- a/languages/Algorithm/models/Algorithm.behavior.mps
+++ b/languages/Algorithm/models/Algorithm.behavior.mps
@@ -14,6 +14,7 @@
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
     <import index="o8zo" ref="r:314576fc-3aee-4386-a0a5-a38348ac317d(jetbrains.mps.scope)" />
     <import index="yvgz" ref="r:3b411c10-569a-4299-9505-176144359d3b(Algorithm.structure)" />
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" implicit="true" />
   </imports>
   <registry>
     <language id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior">
@@ -36,6 +37,7 @@
         <child id="1082485599096" name="statements" index="9aQI4" />
       </concept>
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
         <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
@@ -48,6 +50,9 @@
       </concept>
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
@@ -72,6 +77,7 @@
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
         <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
         <child id="1068580123160" name="condition" index="3clFbw" />
@@ -81,6 +87,7 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
       </concept>
@@ -157,6 +164,10 @@
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
+      <concept id="1144195091934" name="jetbrains.mps.lang.smodel.structure.Node_IsRoleOperation" flags="nn" index="1BlSNk">
+        <reference id="1144195362400" name="conceptOfParent" index="1BmUXE" />
+        <reference id="1144195396777" name="linkInParent" index="1Bn3mz" />
+      </concept>
       <concept id="1172326502327" name="jetbrains.mps.lang.smodel.structure.Concept_IsExactlyOperation" flags="nn" index="3O6GUB">
         <child id="1206733650006" name="conceptArgument" index="3QVz_e" />
       </concept>
@@ -203,6 +214,7 @@
       </concept>
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
+      <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="nn" index="X8dFx" />
     </language>
   </registry>
   <node concept="13h7C7" id="71WlwW$yyfz">
@@ -474,7 +486,7 @@
       </node>
     </node>
     <node concept="13i0hz" id="7VOfr8WpcKN" role="13h7CS">
-      <property role="TrG5h" value="getDataOrPortName" />
+      <property role="TrG5h" value="getVariableName" />
       <node concept="3Tm1VV" id="7VOfr8WpcKO" role="1B3o_S" />
       <node concept="17QB3L" id="7VOfr8WpcNY" role="3clF45" />
       <node concept="3clFbS" id="7VOfr8WpcKQ" role="3clF47">
@@ -499,12 +511,25 @@
               </node>
             </node>
             <node concept="3cpWs6" id="7VOfr8WpdsE" role="3cqZAp">
-              <node concept="2OqwBi" id="7VOfr8WpdHp" role="3cqZAk">
-                <node concept="37vLTw" id="7VOfr8Wpdvw" role="2Oq$k0">
-                  <ref role="3cqZAo" node="5PE55GMNHrN" resolve="connectedData" />
+              <node concept="3cpWs3" id="1SzGUGQ5ux" role="3cqZAk">
+                <node concept="2OqwBi" id="1SzGUGQ5X1" role="3uHU7w">
+                  <node concept="13iPFW" id="1SzGUGQ5AN" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="1SzGUGQ695" role="2OqNvi">
+                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                  </node>
                 </node>
-                <node concept="3TrcHB" id="7VOfr8WpdQ6" role="2OqNvi">
-                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                <node concept="3cpWs3" id="1SzGUGQ4Cp" role="3uHU7B">
+                  <node concept="2OqwBi" id="7VOfr8WpdHp" role="3uHU7B">
+                    <node concept="37vLTw" id="7VOfr8Wpdvw" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5PE55GMNHrN" resolve="connectedData" />
+                    </node>
+                    <node concept="3TrcHB" id="7VOfr8WpdQ6" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                    </node>
+                  </node>
+                  <node concept="Xl_RD" id="1SzGUGQ4LF" role="3uHU7w">
+                    <property role="Xl_RC" value="_" />
+                  </node>
                 </node>
               </node>
             </node>
@@ -537,16 +562,11 @@
       <node concept="P$JXv" id="7VOfr8Wpj_d" role="lGtFl">
         <node concept="TZ5HA" id="7VOfr8Wpj_e" role="TZ5H$">
           <node concept="1dT_AC" id="7VOfr8Wpj_f" role="1dT_Ay">
-            <property role="1dT_AB" value="if the port's parent is DataBlock, return the block's name" />
-          </node>
-        </node>
-        <node concept="TZ5HA" id="7VOfr8WpjBQ" role="TZ5H$">
-          <node concept="1dT_AC" id="7VOfr8WpjBR" role="1dT_Ay">
-            <property role="1dT_AB" value="else return the port's name" />
+            <property role="1dT_AB" value="get the appropriate variable name for the port" />
           </node>
         </node>
         <node concept="x79VA" id="7VOfr8Wpj_g" role="3nqlJM">
-          <property role="x79VB" value="name of DataBlock or name of port" />
+          <property role="x79VB" value="if parent is DataBlock -&gt; datablock name +" />
         </node>
       </node>
     </node>
@@ -556,6 +576,207 @@
   </node>
   <node concept="13h7C7" id="3yq_xaLGgaX">
     <ref role="13h7C2" to="yvgz:7YUYw4xHlaz" resolve="FunctionBlockContainer" />
+    <node concept="13i0hz" id="44Cv2OMGXvg" role="13h7CS">
+      <property role="TrG5h" value="getScope" />
+      <ref role="13i0hy" to="tpcu:52_Geb4QDV$" resolve="getScope" />
+      <node concept="3Tm1VV" id="44Cv2OMGXvh" role="1B3o_S" />
+      <node concept="3clFbS" id="44Cv2OMGXvq" role="3clF47">
+        <node concept="3clFbJ" id="44Cv2OMHwYq" role="3cqZAp">
+          <node concept="3clFbS" id="44Cv2OMHwYr" role="3clFbx">
+            <node concept="3cpWs8" id="44Cv2OMHwYs" role="3cqZAp">
+              <node concept="3cpWsn" id="44Cv2OMHwYt" role="3cpWs9">
+                <property role="TrG5h" value="validPorts" />
+                <node concept="2I9FWS" id="44Cv2OMHwYu" role="1tU5fm">
+                  <ref role="2I9WkF" to="yvgz:6po$YwiVCCi" resolve="DataPort" />
+                </node>
+                <node concept="2ShNRf" id="44Cv2OMHwYv" role="33vP2m">
+                  <node concept="2T8Vx0" id="44Cv2OMHwYw" role="2ShVmc">
+                    <node concept="2I9FWS" id="44Cv2OMHwYx" role="2T96Bj">
+                      <ref role="2I9WkF" to="yvgz:6po$YwiVCCi" resolve="DataPort" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="44Cv2OMHwYy" role="3cqZAp">
+              <node concept="2OqwBi" id="44Cv2OMHwYz" role="3clFbG">
+                <node concept="37vLTw" id="44Cv2OMHwY$" role="2Oq$k0">
+                  <ref role="3cqZAo" node="44Cv2OMHwYt" resolve="validPorts" />
+                </node>
+                <node concept="liA8E" id="44Cv2OMHwY_" role="2OqNvi">
+                  <ref role="37wK5l" to="33ny:~List.addAll(java.util.Collection)" resolve="addAll" />
+                  <node concept="2OqwBi" id="44Cv2OMHwYA" role="37wK5m">
+                    <node concept="13iPFW" id="44Cv2OMHwYB" role="2Oq$k0" />
+                    <node concept="3Tsc0h" id="44Cv2OMH$9w" role="2OqNvi">
+                      <ref role="3TtcxE" to="yvgz:3eP8Zudp5G8" resolve="data_ports" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="44Cv2OMHwYD" role="3cqZAp">
+              <node concept="2OqwBi" id="44Cv2OMHwYE" role="3clFbG">
+                <node concept="2OqwBi" id="44Cv2OMHwYF" role="2Oq$k0">
+                  <node concept="13iPFW" id="44Cv2OMHwYG" role="2Oq$k0" />
+                  <node concept="3Tsc0h" id="44Cv2OMHwYH" role="2OqNvi">
+                    <ref role="3TtcxE" to="yvgz:4iWYoaWUTsk" resolve="data_blocks" />
+                  </node>
+                </node>
+                <node concept="2es0OD" id="44Cv2OMHwYI" role="2OqNvi">
+                  <node concept="1bVj0M" id="44Cv2OMHwYJ" role="23t8la">
+                    <node concept="3clFbS" id="44Cv2OMHwYK" role="1bW5cS">
+                      <node concept="3clFbF" id="44Cv2OMHwYL" role="3cqZAp">
+                        <node concept="2OqwBi" id="44Cv2OMHwYM" role="3clFbG">
+                          <node concept="37vLTw" id="44Cv2OMHwYN" role="2Oq$k0">
+                            <ref role="3cqZAo" node="44Cv2OMHwYt" resolve="validPorts" />
+                          </node>
+                          <node concept="X8dFx" id="44Cv2OMHwYO" role="2OqNvi">
+                            <node concept="2OqwBi" id="44Cv2OMHwYP" role="25WWJ7">
+                              <node concept="37vLTw" id="44Cv2OMHwYQ" role="2Oq$k0">
+                                <ref role="3cqZAo" node="44Cv2OMHwYS" resolve="dataBlock" />
+                              </node>
+                              <node concept="3Tsc0h" id="44Cv2OMHwYR" role="2OqNvi">
+                                <ref role="3TtcxE" to="yvgz:6jvQBgXExiw" resolve="ports" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="44Cv2OMHwYS" role="1bW2Oz">
+                      <property role="TrG5h" value="dataBlock" />
+                      <node concept="2jxLKc" id="44Cv2OMHwYT" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="44Cv2OMHB8X" role="3cqZAp">
+              <node concept="2OqwBi" id="44Cv2OMHDZY" role="3clFbG">
+                <node concept="2OqwBi" id="44Cv2OMHB_z" role="2Oq$k0">
+                  <node concept="13iPFW" id="44Cv2OMHB8V" role="2Oq$k0" />
+                  <node concept="3Tsc0h" id="44Cv2OMHBPp" role="2OqNvi">
+                    <ref role="3TtcxE" to="yvgz:4iWYoaWUTsf" resolve="function_blocks" />
+                  </node>
+                </node>
+                <node concept="2es0OD" id="44Cv2OMHG0z" role="2OqNvi">
+                  <node concept="1bVj0M" id="44Cv2OMHG0_" role="23t8la">
+                    <node concept="3clFbS" id="44Cv2OMHG0A" role="1bW5cS">
+                      <node concept="3clFbF" id="44Cv2OMHGc5" role="3cqZAp">
+                        <node concept="2OqwBi" id="44Cv2OMHGD7" role="3clFbG">
+                          <node concept="37vLTw" id="44Cv2OMHGc4" role="2Oq$k0">
+                            <ref role="3cqZAo" node="44Cv2OMHwYt" resolve="validPorts" />
+                          </node>
+                          <node concept="liA8E" id="44Cv2OMHH_c" role="2OqNvi">
+                            <ref role="37wK5l" to="33ny:~List.addAll(java.util.Collection)" resolve="addAll" />
+                            <node concept="2OqwBi" id="44Cv2OMHHXX" role="37wK5m">
+                              <node concept="37vLTw" id="44Cv2OMHHJc" role="2Oq$k0">
+                                <ref role="3cqZAo" node="44Cv2OMHG0B" resolve="functionBlock" />
+                              </node>
+                              <node concept="3Tsc0h" id="44Cv2OMHInC" role="2OqNvi">
+                                <ref role="3TtcxE" to="yvgz:3eP8Zudp5G8" resolve="data_ports" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="44Cv2OMHG0B" role="1bW2Oz">
+                      <property role="TrG5h" value="functionBlock" />
+                      <node concept="2jxLKc" id="44Cv2OMHG0C" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="44Cv2OMHLZ8" role="3cqZAp">
+              <node concept="2OqwBi" id="44Cv2OMHOoz" role="3clFbG">
+                <node concept="2OqwBi" id="44Cv2OMHMzT" role="2Oq$k0">
+                  <node concept="13iPFW" id="44Cv2OMHLZ6" role="2Oq$k0" />
+                  <node concept="3Tsc0h" id="44Cv2OMHMLz" role="2OqNvi">
+                    <ref role="3TtcxE" to="yvgz:4iWYoaWUTsh" resolve="scheduler_blocks" />
+                  </node>
+                </node>
+                <node concept="2es0OD" id="44Cv2OMHQde" role="2OqNvi">
+                  <node concept="1bVj0M" id="44Cv2OMHQdg" role="23t8la">
+                    <node concept="3clFbS" id="44Cv2OMHQdh" role="1bW5cS">
+                      <node concept="3clFbF" id="44Cv2OMHQtT" role="3cqZAp">
+                        <node concept="2OqwBi" id="44Cv2OMHQRQ" role="3clFbG">
+                          <node concept="37vLTw" id="44Cv2OMHQtS" role="2Oq$k0">
+                            <ref role="3cqZAo" node="44Cv2OMHwYt" resolve="validPorts" />
+                          </node>
+                          <node concept="liA8E" id="44Cv2OMHRZP" role="2OqNvi">
+                            <ref role="37wK5l" to="33ny:~List.addAll(java.util.Collection)" resolve="addAll" />
+                            <node concept="2OqwBi" id="44Cv2OMHSIE" role="37wK5m">
+                              <node concept="37vLTw" id="44Cv2OMHSc$" role="2Oq$k0">
+                                <ref role="3cqZAo" node="44Cv2OMHQdi" resolve="schedulerBlock" />
+                              </node>
+                              <node concept="3Tsc0h" id="44Cv2OMHT1Z" role="2OqNvi">
+                                <ref role="3TtcxE" to="yvgz:6jvQBgXG1ad" resolve="data_ports" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="44Cv2OMHQdi" role="1bW2Oz">
+                      <property role="TrG5h" value="schedulerBlock" />
+                      <node concept="2jxLKc" id="44Cv2OMHQdj" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="44Cv2OMHwYU" role="3cqZAp">
+              <node concept="2YIFZM" id="44Cv2OMHwYV" role="3cqZAk">
+                <ref role="37wK5l" to="o8zo:4IP40Bi3eAf" resolve="forNamedElements" />
+                <ref role="1Pybhc" to="o8zo:4IP40Bi3e_R" resolve="ListScope" />
+                <node concept="37vLTw" id="44Cv2OMHwYW" role="37wK5m">
+                  <ref role="3cqZAo" node="44Cv2OMHwYt" resolve="validPorts" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="44Cv2OMHwYX" role="3clFbw">
+            <node concept="37vLTw" id="44Cv2OMHwYY" role="2Oq$k0">
+              <ref role="3cqZAo" node="44Cv2OMGXvt" resolve="child" />
+            </node>
+            <node concept="1BlSNk" id="44Cv2OMHwYZ" role="2OqNvi">
+              <ref role="1BmUXE" to="yvgz:7YUYw4xHlaz" resolve="FunctionBlockContainer" />
+              <ref role="1Bn3mz" to="yvgz:4iWYoaWUTso" resolve="closures" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="44Cv2OMHwXN" role="3cqZAp" />
+        <node concept="3clFbF" id="44Cv2OMGXv_" role="3cqZAp">
+          <node concept="2OqwBi" id="44Cv2OMGXvy" role="3clFbG">
+            <node concept="13iAh5" id="44Cv2OMGXvz" role="2Oq$k0">
+              <ref role="3eA5LN" to="tpck:3fifI_xCcJN" resolve="ScopeProvider" />
+            </node>
+            <node concept="2qgKlT" id="44Cv2OMGXv$" role="2OqNvi">
+              <ref role="37wK5l" to="tpcu:52_Geb4QDV$" resolve="getScope" />
+              <node concept="37vLTw" id="44Cv2OMGXvw" role="37wK5m">
+                <ref role="3cqZAo" node="44Cv2OMGXvr" resolve="kind" />
+              </node>
+              <node concept="37vLTw" id="44Cv2OMGXvx" role="37wK5m">
+                <ref role="3cqZAo" node="44Cv2OMGXvt" resolve="child" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="44Cv2OMGXvr" role="3clF46">
+        <property role="TrG5h" value="kind" />
+        <node concept="3bZ5Sz" id="44Cv2OMGXvs" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="44Cv2OMGXvt" role="3clF46">
+        <property role="TrG5h" value="child" />
+        <node concept="3Tqbb2" id="44Cv2OMGXvu" role="1tU5fm" />
+      </node>
+      <node concept="3uibUv" id="44Cv2OMGXvv" role="3clF45">
+        <ref role="3uigEE" to="o8zo:3fifI_xCtN$" resolve="Scope" />
+      </node>
+    </node>
     <node concept="13i0hz" id="1Fy8yZq9o69" role="13h7CS">
       <property role="TrG5h" value="findConnectedDataPorts" />
       <node concept="3Tm1VV" id="1Fy8yZq9o6a" role="1B3o_S" />
@@ -800,6 +1021,136 @@
     </node>
     <node concept="13hLZK" id="3yq_xaLGgaY" role="13h7CW">
       <node concept="3clFbS" id="3yq_xaLGgaZ" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="44Cv2OMC$ig">
+    <ref role="13h7C2" to="yvgz:5o1iPWxUm1h" resolve="DataBlockContainer" />
+    <node concept="13hLZK" id="44Cv2OMC$ih" role="13h7CW">
+      <node concept="3clFbS" id="44Cv2OMC$ii" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="44Cv2OMEeIm" role="13h7CS">
+      <property role="TrG5h" value="getScope" />
+      <ref role="13i0hy" to="tpcu:52_Geb4QDV$" resolve="getScope" />
+      <node concept="3Tm1VV" id="44Cv2OMEeIn" role="1B3o_S" />
+      <node concept="3clFbS" id="44Cv2OMEeIw" role="3clF47">
+        <node concept="3clFbJ" id="44Cv2OMEeXk" role="3cqZAp">
+          <node concept="3clFbS" id="44Cv2OMEeXm" role="3clFbx">
+            <node concept="3cpWs8" id="44Cv2OMEfNc" role="3cqZAp">
+              <node concept="3cpWsn" id="44Cv2OMEfNf" role="3cpWs9">
+                <property role="TrG5h" value="validPorts" />
+                <node concept="2I9FWS" id="44Cv2OMEfNa" role="1tU5fm">
+                  <ref role="2I9WkF" to="yvgz:6po$YwiVCCi" resolve="DataPort" />
+                </node>
+                <node concept="2ShNRf" id="44Cv2OMEfPs" role="33vP2m">
+                  <node concept="2T8Vx0" id="44Cv2OMEfPq" role="2ShVmc">
+                    <node concept="2I9FWS" id="44Cv2OMEfPr" role="2T96Bj">
+                      <ref role="2I9WkF" to="yvgz:6po$YwiVCCi" resolve="DataPort" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="44Cv2OMEgBT" role="3cqZAp">
+              <node concept="2OqwBi" id="44Cv2OMEiMl" role="3clFbG">
+                <node concept="37vLTw" id="44Cv2OMEgBR" role="2Oq$k0">
+                  <ref role="3cqZAo" node="44Cv2OMEfNf" resolve="validPorts" />
+                </node>
+                <node concept="liA8E" id="44Cv2OMEmy2" role="2OqNvi">
+                  <ref role="37wK5l" to="33ny:~List.addAll(java.util.Collection)" resolve="addAll" />
+                  <node concept="2OqwBi" id="44Cv2OMEmVB" role="37wK5m">
+                    <node concept="13iPFW" id="44Cv2OMEmEK" role="2Oq$k0" />
+                    <node concept="3Tsc0h" id="44Cv2OMEnhY" role="2OqNvi">
+                      <ref role="3TtcxE" to="yvgz:6jvQBgXExiw" resolve="ports" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="44Cv2OMEnKH" role="3cqZAp">
+              <node concept="2OqwBi" id="44Cv2OMEqm6" role="3clFbG">
+                <node concept="2OqwBi" id="44Cv2OMEoc1" role="2Oq$k0">
+                  <node concept="13iPFW" id="44Cv2OMEnKF" role="2Oq$k0" />
+                  <node concept="3Tsc0h" id="44Cv2OMEoqV" role="2OqNvi">
+                    <ref role="3TtcxE" to="yvgz:5o1iPWxUm1i" resolve="data_blocks" />
+                  </node>
+                </node>
+                <node concept="2es0OD" id="44Cv2OMEslV" role="2OqNvi">
+                  <node concept="1bVj0M" id="44Cv2OMEslX" role="23t8la">
+                    <node concept="3clFbS" id="44Cv2OMEslY" role="1bW5cS">
+                      <node concept="3clFbF" id="44Cv2OMEszR" role="3cqZAp">
+                        <node concept="2OqwBi" id="44Cv2OMEund" role="3clFbG">
+                          <node concept="37vLTw" id="44Cv2OMEszQ" role="2Oq$k0">
+                            <ref role="3cqZAo" node="44Cv2OMEfNf" resolve="validPorts" />
+                          </node>
+                          <node concept="X8dFx" id="44Cv2OMEvsI" role="2OqNvi">
+                            <node concept="2OqwBi" id="44Cv2OMEwYs" role="25WWJ7">
+                              <node concept="37vLTw" id="44Cv2OMEwCt" role="2Oq$k0">
+                                <ref role="3cqZAo" node="44Cv2OMEslZ" resolve="dataBlock" />
+                              </node>
+                              <node concept="3Tsc0h" id="44Cv2OMExsC" role="2OqNvi">
+                                <ref role="3TtcxE" to="yvgz:6jvQBgXExiw" resolve="ports" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="44Cv2OMEslZ" role="1bW2Oz">
+                      <property role="TrG5h" value="dataBlock" />
+                      <node concept="2jxLKc" id="44Cv2OMEsm0" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="44Cv2OMEfQd" role="3cqZAp">
+              <node concept="2YIFZM" id="44Cv2OMEgry" role="3cqZAk">
+                <ref role="37wK5l" to="o8zo:4IP40Bi3eAf" resolve="forNamedElements" />
+                <ref role="1Pybhc" to="o8zo:4IP40Bi3e_R" resolve="ListScope" />
+                <node concept="37vLTw" id="44Cv2OMEgu_" role="37wK5m">
+                  <ref role="3cqZAo" node="44Cv2OMEfNf" resolve="validPorts" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="44Cv2OMEf6Y" role="3clFbw">
+            <node concept="37vLTw" id="44Cv2OMEeYg" role="2Oq$k0">
+              <ref role="3cqZAo" node="44Cv2OMEeIz" resolve="child" />
+            </node>
+            <node concept="1BlSNk" id="44Cv2OMGZwP" role="2OqNvi">
+              <ref role="1BmUXE" to="yvgz:5o1iPWxUm1h" resolve="DataBlockContainer" />
+              <ref role="1Bn3mz" to="yvgz:5o1iPWxUm1k" resolve="closures" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="44Cv2OMEeIF" role="3cqZAp">
+          <node concept="2OqwBi" id="44Cv2OMEeIC" role="3clFbG">
+            <node concept="13iAh5" id="44Cv2OMEeID" role="2Oq$k0">
+              <ref role="3eA5LN" to="tpck:3fifI_xCcJN" resolve="ScopeProvider" />
+            </node>
+            <node concept="2qgKlT" id="44Cv2OMEeIE" role="2OqNvi">
+              <ref role="37wK5l" to="tpcu:52_Geb4QDV$" resolve="getScope" />
+              <node concept="37vLTw" id="44Cv2OMEeIA" role="37wK5m">
+                <ref role="3cqZAo" node="44Cv2OMEeIx" resolve="kind" />
+              </node>
+              <node concept="37vLTw" id="44Cv2OMEeIB" role="37wK5m">
+                <ref role="3cqZAo" node="44Cv2OMEeIz" resolve="child" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="44Cv2OMEeIx" role="3clF46">
+        <property role="TrG5h" value="kind" />
+        <node concept="3bZ5Sz" id="44Cv2OMEeIy" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="44Cv2OMEeIz" role="3clF46">
+        <property role="TrG5h" value="child" />
+        <node concept="3Tqbb2" id="44Cv2OMEeI$" role="1tU5fm" />
+      </node>
+      <node concept="3uibUv" id="44Cv2OMEeI_" role="3clF45">
+        <ref role="3uigEE" to="o8zo:3fifI_xCtN$" resolve="Scope" />
+      </node>
     </node>
   </node>
 </model>

--- a/languages/Algorithm/models/Algorithm.constraints.mps
+++ b/languages/Algorithm/models/Algorithm.constraints.mps
@@ -156,5 +156,20 @@
       </node>
     </node>
   </node>
+  <node concept="1M2fIO" id="44Cv2OMFua_">
+    <ref role="1M2myG" to="yvgz:6po$YwiVCCf" resolve="DataConnector" />
+    <node concept="1N5Pfh" id="44Cv2OMFuaA" role="1Mr941">
+      <ref role="1N5Vy1" to="yvgz:6po$YwiVCCg" resolve="port1" />
+      <node concept="1dDu$B" id="44Cv2OMFud1" role="1N6uqs">
+        <ref role="1dDu$A" to="yvgz:6po$YwiVCCi" resolve="DataPort" />
+      </node>
+    </node>
+    <node concept="1N5Pfh" id="44Cv2OMFueD" role="1Mr941">
+      <ref role="1N5Vy1" to="yvgz:6po$YwiVFhL" resolve="port2" />
+      <node concept="1dDu$B" id="44Cv2OMFugj" role="1N6uqs">
+        <ref role="1dDu$A" to="yvgz:6po$YwiVCCi" resolve="DataPort" />
+      </node>
+    </node>
+  </node>
 </model>
 

--- a/languages/Algorithm/models/Algorithm.structure.mps
+++ b/languages/Algorithm/models/Algorithm.structure.mps
@@ -203,6 +203,9 @@
       <property role="20lbJX" value="fLJekj5/_0__n" />
       <ref role="20lvS9" node="6jvQBgXFn4Y" resolve="TriggerConnector" />
     </node>
+    <node concept="PrWs8" id="44Cv2OMGVBt" role="PzmwI">
+      <ref role="PrY4T" to="tpck:3fifI_xCcJN" resolve="ScopeProvider" />
+    </node>
   </node>
   <node concept="1TIwiD" id="6jvQBgXEYiM">
     <property role="EcuMT" value="7268768516385006770" />
@@ -336,6 +339,9 @@
       <property role="20kJfa" value="closures" />
       <property role="20lbJX" value="fLJekj5/_0__n" />
       <ref role="20lvS9" node="6po$YwiVCCf" resolve="DataConnector" />
+    </node>
+    <node concept="PrWs8" id="44Cv2OMEeIc" role="PzmwI">
+      <ref role="PrY4T" to="tpck:3fifI_xCcJN" resolve="ScopeProvider" />
     </node>
   </node>
   <node concept="1TIwiD" id="5o1iPWxU$71">

--- a/languages/Algorithm/models/Algorithm.typesystem.mps
+++ b/languages/Algorithm/models/Algorithm.typesystem.mps
@@ -7,6 +7,7 @@
   </languages>
   <imports>
     <import index="yvgz" ref="r:3b411c10-569a-4299-9505-176144359d3b(Algorithm.structure)" implicit="true" />
+    <import index="ixp9" ref="r:172690fd-5286-4218-b525-cadaaf47af22(Algorithm.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -44,16 +45,22 @@
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1081506762703" name="jetbrains.mps.baseLanguage.structure.GreaterThanExpression" flags="nn" index="3eOSWO" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
       <concept id="1214918800624" name="jetbrains.mps.baseLanguage.structure.PostfixIncrementExpression" flags="nn" index="3uNrnE" />
+      <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
@@ -99,6 +106,22 @@
       <concept id="4705942098322467729" name="jetbrains.mps.lang.smodel.structure.EnumMemberReference" flags="ng" index="21nZrQ">
         <reference id="4705942098322467736" name="decl" index="21nZrZ" />
       </concept>
+      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
+        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
+      </concept>
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
+        <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
+        <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
+      </concept>
+      <concept id="1145383075378" name="jetbrains.mps.lang.smodel.structure.SNodeListType" flags="in" index="2I9FWS" />
+      <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
+      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI">
+        <property id="1238684351431" name="asCast" index="1BlNFB" />
+      </concept>
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
       <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
         <reference id="1138056395725" name="property" index="3TsBF5" />
       </concept>
@@ -110,6 +133,9 @@
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+      </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
@@ -120,6 +146,7 @@
       </concept>
       <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
+      <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
     </language>
   </registry>
   <node concept="18kY7G" id="5jlbthjHQSN">
@@ -248,6 +275,111 @@
     <node concept="1YaCAy" id="WUr5EYI42N" role="1YuTPh">
       <property role="TrG5h" value="dataConnector" />
       <ref role="1YaFvo" to="yvgz:6po$YwiVCCf" resolve="DataConnector" />
+    </node>
+  </node>
+  <node concept="18kY7G" id="5Tr1VsJGw_T">
+    <property role="TrG5h" value="check_FixedDataFlowSchedulerBlock" />
+    <property role="3GE5qa" value="definitions" />
+    <node concept="3clFbS" id="5Tr1VsJGw_U" role="18ibNy">
+      <node concept="3cpWs8" id="5Tr1VsJG_zw" role="3cqZAp">
+        <node concept="3cpWsn" id="5Tr1VsJG_zz" role="3cpWs9">
+          <property role="TrG5h" value="parentContainer" />
+          <node concept="3Tqbb2" id="5Tr1VsJG_zu" role="1tU5fm">
+            <ref role="ehGHo" to="yvgz:7YUYw4xHlaz" resolve="FunctionBlockContainer" />
+          </node>
+          <node concept="1PxgMI" id="5Tr1VsJGAbJ" role="33vP2m">
+            <property role="1BlNFB" value="true" />
+            <node concept="chp4Y" id="5Tr1VsJGAgx" role="3oSUPX">
+              <ref role="cht4Q" to="yvgz:7YUYw4xHlaz" resolve="FunctionBlockContainer" />
+            </node>
+            <node concept="2OqwBi" id="5Tr1VsJG_JZ" role="1m5AlR">
+              <node concept="1YBJjd" id="5Tr1VsJG_$F" role="2Oq$k0">
+                <ref role="1YBMHb" node="5Tr1VsJGw_W" resolve="fixedDataFlowSchedulerBlock" />
+              </node>
+              <node concept="1mfA1w" id="5Tr1VsJGA3y" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbF" id="5Tr1VsJGwA1" role="3cqZAp">
+        <node concept="2OqwBi" id="5Tr1VsJGyyP" role="3clFbG">
+          <node concept="2OqwBi" id="5Tr1VsJGwJe" role="2Oq$k0">
+            <node concept="1YBJjd" id="5Tr1VsJGwA0" role="2Oq$k0">
+              <ref role="1YBMHb" node="5Tr1VsJGw_W" resolve="fixedDataFlowSchedulerBlock" />
+            </node>
+            <node concept="3Tsc0h" id="5Tr1VsJGwUo" role="2OqNvi">
+              <ref role="3TtcxE" to="yvgz:3EtQu_veq3" resolve="schedule" />
+            </node>
+          </node>
+          <node concept="2es0OD" id="5Tr1VsJG$aF" role="2OqNvi">
+            <node concept="1bVj0M" id="5Tr1VsJG$aH" role="23t8la">
+              <node concept="3clFbS" id="5Tr1VsJG$aI" role="1bW5cS">
+                <node concept="3cpWs8" id="5Tr1VsJGBRr" role="3cqZAp">
+                  <node concept="3cpWsn" id="5Tr1VsJGBRs" role="3cpWs9">
+                    <property role="TrG5h" value="connectedTrigPorts" />
+                    <node concept="2I9FWS" id="5Tr1VsJGBRq" role="1tU5fm" />
+                    <node concept="2OqwBi" id="5Tr1VsJGABK" role="33vP2m">
+                      <node concept="37vLTw" id="5Tr1VsJGAkf" role="2Oq$k0">
+                        <ref role="3cqZAo" node="5Tr1VsJG_zz" resolve="parentContainer" />
+                      </node>
+                      <node concept="2qgKlT" id="5Tr1VsJGAPk" role="2OqNvi">
+                        <ref role="37wK5l" to="ixp9:2RC7aVK84L5" resolve="findConnectedTriggerPorts" />
+                        <node concept="2OqwBi" id="5Tr1VsJGB7o" role="37wK5m">
+                          <node concept="37vLTw" id="5Tr1VsJGAW2" role="2Oq$k0">
+                            <ref role="3cqZAo" node="5Tr1VsJG$aJ" resolve="trigPortRef" />
+                          </node>
+                          <node concept="3TrEf2" id="5Tr1VsJGBox" role="2OqNvi">
+                            <ref role="3Tt5mk" to="yvgz:3EtQu_woIa" resolve="trigger_port" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="5Tr1VsJG$lH" role="3cqZAp">
+                  <node concept="3y3z36" id="5Tr1VsJGFeD" role="3clFbw">
+                    <node concept="3cmrfG" id="5Tr1VsJGFGq" role="3uHU7w">
+                      <property role="3cmrfH" value="1" />
+                    </node>
+                    <node concept="2OqwBi" id="5Tr1VsJG$_c" role="3uHU7B">
+                      <node concept="37vLTw" id="5Tr1VsJGCiD" role="2Oq$k0">
+                        <ref role="3cqZAo" node="5Tr1VsJGBRs" resolve="connectedTrigPorts" />
+                      </node>
+                      <node concept="34oBXx" id="5Tr1VsJGDXz" role="2OqNvi" />
+                    </node>
+                  </node>
+                  <node concept="3clFbS" id="5Tr1VsJG$lJ" role="3clFbx">
+                    <node concept="2MkqsV" id="5Tr1VsJGIsI" role="3cqZAp">
+                      <node concept="37vLTw" id="5Tr1VsJGI_Q" role="1urrMF">
+                        <ref role="3cqZAo" node="5Tr1VsJG$aJ" resolve="trigPortRef" />
+                      </node>
+                      <node concept="3cpWs3" id="5Tr1VsJE5UC" role="2MkJ7o">
+                        <node concept="2OqwBi" id="5Tr1VsJE8jo" role="3uHU7w">
+                          <node concept="37vLTw" id="5Tr1VsJGGBG" role="2Oq$k0">
+                            <ref role="3cqZAo" node="5Tr1VsJGBRs" resolve="connectedTrigPorts" />
+                          </node>
+                          <node concept="34oBXx" id="5Tr1VsJEaga" role="2OqNvi" />
+                        </node>
+                        <node concept="Xl_RD" id="5Tr1VsJE4_K" role="3uHU7B">
+                          <property role="Xl_RC" value="expected exactly 1 connected trigger port, found: " />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="Rh6nW" id="5Tr1VsJG$aJ" role="1bW2Oz">
+                <property role="TrG5h" value="trigPortRef" />
+                <node concept="2jxLKc" id="5Tr1VsJG$aK" role="1tU5fm" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="5Tr1VsJGw_W" role="1YuTPh">
+      <property role="TrG5h" value="fixedDataFlowSchedulerBlock" />
+      <ref role="1YaFvo" to="yvgz:3EtQu_veq2" resolve="FixedDataFlowSchedulerBlock" />
     </node>
   </node>
 </model>

--- a/languages/Algorithm_CGenerator/Algorithm_CGenerator.mpl
+++ b/languages/Algorithm_CGenerator/Algorithm_CGenerator.mpl
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<language namespace="Algorithm_CGenerator" uuid="8d7c3baa-c6d4-442a-843a-34b7b957af1e" languageVersion="0" moduleVersion="0">
+  <models>
+    <modelRoot contentPath="${module}" type="default">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet type="java">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+  </facets>
+  <accessoryModels />
+  <generators>
+    <generator alias="main" namespace="Algorithm_CGenerator#01" uuid="40039aa5-5dfd-4b77-8737-89f5a034d3fd">
+      <models>
+        <modelRoot contentPath="${module}/generator" type="default">
+          <sourceRoot location="templates" />
+        </modelRoot>
+      </models>
+      <facets>
+        <facet type="java" />
+      </facets>
+      <external-templates />
+      <dependencies>
+        <dependency reexport="false">990507d3-3527-4c54-bfe9-0ca3c9c6247a(com.dslfoundry.plaintextgen)</dependency>
+      </dependencies>
+      <languageVersions>
+        <language slang="l:990507d3-3527-4c54-bfe9-0ca3c9c6247a:com.dslfoundry.plaintextgen" version="0" />
+        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="9" />
+        <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+        <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
+        <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+        <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
+        <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
+        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="3" />
+        <language slang="l:d7706f63-9be2-479c-a3da-ae92af1e64d5:jetbrains.mps.lang.generator.generationContext" version="2" />
+        <language slang="l:289fcc83-6543-41e8-a5ca-768235715ce4:jetbrains.mps.lang.generator.generationParameters" version="0" />
+        <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+        <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="4" />
+        <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
+        <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="17" />
+        <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
+        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+      </languageVersions>
+      <dependencyVersions>
+        <module reference="a8f70f9e-ef01-499f-885c-c79273fa1695(Algorithm)" version="0" />
+        <module reference="8d7c3baa-c6d4-442a-843a-34b7b957af1e(Algorithm_CGenerator)" version="0" />
+        <module reference="40039aa5-5dfd-4b77-8737-89f5a034d3fd(Algorithm_CGenerator#01)" version="0" />
+        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+        <module reference="990507d3-3527-4c54-bfe9-0ca3c9c6247a(com.dslfoundry.plaintextgen)" version="0" />
+        <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+        <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+        <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
+        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+        <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
+        <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
+      </dependencyVersions>
+      <mapping-priorities />
+    </generator>
+  </generators>
+  <sourcePath />
+  <dependencies>
+    <dependency reexport="false">990507d3-3527-4c54-bfe9-0ca3c9c6247a(com.dslfoundry.plaintextgen)</dependency>
+  </dependencies>
+  <languageVersions>
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:f4ad079d-bc71-4ffb-9600-9328705cf998:jetbrains.mps.lang.descriptor" version="0" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="a8f70f9e-ef01-499f-885c-c79273fa1695(Algorithm)" version="0" />
+    <module reference="8d7c3baa-c6d4-442a-843a-34b7b957af1e(Algorithm_CGenerator)" version="0" />
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="990507d3-3527-4c54-bfe9-0ca3c9c6247a(com.dslfoundry.plaintextgen)" version="0" />
+    <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+    <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+    <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
+    <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />
+    <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
+    <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
+  </dependencyVersions>
+  <extendedLanguages>
+    <extendedLanguage>a8f70f9e-ef01-499f-885c-c79273fa1695(Algorithm)</extendedLanguage>
+  </extendedLanguages>
+</language>
+

--- a/languages/Algorithm_CGenerator/Algorithm_CGenerator.mpl
+++ b/languages/Algorithm_CGenerator/Algorithm_CGenerator.mpl
@@ -19,11 +19,14 @@
         </modelRoot>
       </models>
       <facets>
-        <facet type="java" />
+        <facet type="java">
+          <classes generated="true" path="${module}/generator/classes_gen" />
+        </facet>
       </facets>
       <external-templates />
       <dependencies>
         <dependency reexport="false">990507d3-3527-4c54-bfe9-0ca3c9c6247a(com.dslfoundry.plaintextgen)</dependency>
+        <dependency reexport="false">a8f70f9e-ef01-499f-885c-c79273fa1695(Algorithm)</dependency>
       </dependencies>
       <languageVersions>
         <language slang="l:990507d3-3527-4c54-bfe9-0ca3c9c6247a:com.dslfoundry.plaintextgen" version="0" />
@@ -66,6 +69,7 @@
   <sourcePath />
   <dependencies>
     <dependency reexport="false">990507d3-3527-4c54-bfe9-0ca3c9c6247a(com.dslfoundry.plaintextgen)</dependency>
+    <dependency reexport="false">a8f70f9e-ef01-499f-885c-c79273fa1695(Algorithm)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
@@ -87,8 +91,6 @@
     <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
     <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
   </dependencyVersions>
-  <extendedLanguages>
-    <extendedLanguage>a8f70f9e-ef01-499f-885c-c79273fa1695(Algorithm)</extendedLanguage>
-  </extendedLanguages>
+  <extendedLanguages />
 </language>
 

--- a/languages/Algorithm_CGenerator/generator/templates/main@generator.mps
+++ b/languages/Algorithm_CGenerator/generator/templates/main@generator.mps
@@ -21,12 +21,6 @@
       </concept>
       <concept id="1215695189714" name="jetbrains.mps.baseLanguage.structure.PlusAssignmentExpression" flags="nn" index="d57v9" />
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
-      <concept id="1239714755177" name="jetbrains.mps.baseLanguage.structure.AbstractUnaryNumberOperation" flags="nn" index="2$Kvd9">
-        <child id="1239714902950" name="expression" index="2$L3a6" />
-      </concept>
-      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
-        <child id="1154032183016" name="body" index="2LFqv$" />
-      </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -40,7 +34,6 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
-      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
@@ -74,7 +67,6 @@
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1081506762703" name="jetbrains.mps.baseLanguage.structure.GreaterThanExpression" flags="nn" index="3eOSWO" />
-      <concept id="1081506773034" name="jetbrains.mps.baseLanguage.structure.LessThanExpression" flags="nn" index="3eOVzh" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
@@ -84,15 +76,7 @@
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
-      <concept id="1214918800624" name="jetbrains.mps.baseLanguage.structure.PostfixIncrementExpression" flags="nn" index="3uNrnE" />
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
-      <concept id="1144230876926" name="jetbrains.mps.baseLanguage.structure.AbstractForStatement" flags="nn" index="1DupvO">
-        <child id="1144230900587" name="variable" index="1Duv9x" />
-      </concept>
-      <concept id="1144231330558" name="jetbrains.mps.baseLanguage.structure.ForStatement" flags="nn" index="1Dw8fO">
-        <child id="1144231399730" name="condition" index="1Dwp0S" />
-        <child id="1144231408325" name="iteration" index="1Dwrff" />
-      </concept>
     </language>
     <language id="b401a680-8325-4110-8fd3-84331ff25bef" name="jetbrains.mps.lang.generator">
       <concept id="1510949579266781519" name="jetbrains.mps.lang.generator.structure.TemplateCallMacro" flags="ln" index="5jKBG" />
@@ -240,15 +224,12 @@
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
-      <concept id="1225711141656" name="jetbrains.mps.baseLanguage.collections.structure.ListElementAccessExpression" flags="nn" index="1y4W85">
-        <child id="1225711182005" name="list" index="1y566C" />
-        <child id="1225711191269" name="index" index="1y58nS" />
-      </concept>
     </language>
   </registry>
   <node concept="bUwia" id="5Tr1VsJDrkr">
     <property role="TrG5h" value="main" />
     <node concept="3lhOvk" id="5Tr1VsJDt9h" role="3lj3bC">
+      <property role="36QftV" value="true" />
       <ref role="30HIoZ" to="yvgz:7YUYw4xHlaz" resolve="FunctionBlockContainer" />
       <ref role="3lhOvi" node="5Tr1VsJDsug" resolve="function_name" />
     </node>
@@ -542,7 +523,7 @@
           </node>
         </node>
         <node concept="356sEF" id="5Tr1VsJLq3_" role="356sEH">
-          <property role="TrG5h" value="function signature" />
+          <property role="TrG5h" value="params" />
           <node concept="5jKBG" id="5Tr1VsJM0XP" role="lGtFl">
             <ref role="v9R2y" node="5Tr1VsJLpoy" resolve="include_FunctionDefParams" />
           </node>
@@ -864,308 +845,11 @@
             </node>
           </node>
         </node>
-        <node concept="356sEF" id="5Tr1VsJMau8" role="356sEH">
-          <property role="TrG5h" value="(" />
-        </node>
-        <node concept="356sEF" id="Ho3faVHPY_" role="356sEH">
-          <property role="TrG5h" value="function_call()" />
-          <node concept="17Uvod" id="Ho3faVHPYC" role="lGtFl">
-            <property role="2qtEX9" value="name" />
-            <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
-            <node concept="3zFVjK" id="Ho3faVHPYD" role="3zH0cK">
-              <node concept="3clFbS" id="Ho3faVHPYE" role="2VODD2">
-                <node concept="3cpWs8" id="5Tr1VsJMGfe" role="3cqZAp">
-                  <node concept="3cpWsn" id="5Tr1VsJMGfh" role="3cpWs9">
-                    <property role="TrG5h" value="parent" />
-                    <node concept="3Tqbb2" id="5Tr1VsJMGfc" role="1tU5fm">
-                      <ref role="ehGHo" to="yvgz:7YUYw4xHlaz" resolve="FunctionBlockContainer" />
-                    </node>
-                    <node concept="1PxgMI" id="5Tr1VsJMHrX" role="33vP2m">
-                      <property role="1BlNFB" value="true" />
-                      <node concept="chp4Y" id="5Tr1VsJMHDO" role="3oSUPX">
-                        <ref role="cht4Q" to="yvgz:7YUYw4xHlaz" resolve="FunctionBlockContainer" />
-                      </node>
-                      <node concept="2OqwBi" id="5Tr1VsJMH1P" role="1m5AlR">
-                        <node concept="30H73N" id="5Tr1VsJMGFc" role="2Oq$k0" />
-                        <node concept="1mfA1w" id="5Tr1VsJMHdv" role="2OqNvi" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbJ" id="5Tr1VsJMI0z" role="3cqZAp">
-                  <node concept="3clFbS" id="5Tr1VsJMI0_" role="3clFbx">
-                    <node concept="3cpWs8" id="5Tr1VsJMWk4" role="3cqZAp">
-                      <node concept="3cpWsn" id="5Tr1VsJMWk7" role="3cpWs9">
-                        <property role="TrG5h" value="errString" />
-                        <node concept="17QB3L" id="5Tr1VsJMWk2" role="1tU5fm" />
-                        <node concept="3cpWs3" id="5Tr1VsJMNWL" role="33vP2m">
-                          <node concept="2OqwBi" id="5Tr1VsJMP9I" role="3uHU7w">
-                            <node concept="2OqwBi" id="5Tr1VsJMOud" role="2Oq$k0">
-                              <node concept="30H73N" id="5Tr1VsJMO39" role="2Oq$k0" />
-                              <node concept="1mfA1w" id="5Tr1VsJMOX0" role="2OqNvi" />
-                            </node>
-                            <node concept="2qgKlT" id="5Tr1VsJMPlq" role="2OqNvi">
-                              <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
-                            </node>
-                          </node>
-                          <node concept="3cpWs3" id="5Tr1VsJMMe1" role="3uHU7B">
-                            <node concept="3cpWs3" id="5Tr1VsJMKF3" role="3uHU7B">
-                              <node concept="Xl_RD" id="5Tr1VsJMIMZ" role="3uHU7B">
-                                <property role="Xl_RC" value="can't cast parent of function '" />
-                              </node>
-                              <node concept="2OqwBi" id="5Tr1VsJMLbg" role="3uHU7w">
-                                <node concept="30H73N" id="5Tr1VsJMKK_" role="2Oq$k0" />
-                                <node concept="3TrcHB" id="5Tr1VsJMLnA" role="2OqNvi">
-                                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="Xl_RD" id="5Tr1VsJMMkd" role="3uHU7w">
-                              <property role="Xl_RC" value="' as FunctionBlockContainer, parent: " />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="RRSsy" id="5Tr1VsJMIMX" role="3cqZAp">
-                      <property role="RRSoG" value="gZ5fh_4/error" />
-                      <node concept="37vLTw" id="5Tr1VsJMY7M" role="RRSoy">
-                        <ref role="3cqZAo" node="5Tr1VsJMWk7" resolve="errString" />
-                      </node>
-                      <node concept="2ShNRf" id="5Tr1VsJMYf0" role="RRSow">
-                        <node concept="1pGfFk" id="5Tr1VsJMYsG" role="2ShVmc">
-                          <ref role="37wK5l" to="wyt6:~RuntimeException.&lt;init&gt;(java.lang.String)" resolve="RuntimeException" />
-                          <node concept="37vLTw" id="5Tr1VsJMZ2o" role="37wK5m">
-                            <ref role="3cqZAo" node="5Tr1VsJMWk7" resolve="errString" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="2OqwBi" id="5Tr1VsJMIpp" role="3clFbw">
-                    <node concept="37vLTw" id="5Tr1VsJMI6G" role="2Oq$k0">
-                      <ref role="3cqZAo" node="5Tr1VsJMGfh" resolve="parent" />
-                    </node>
-                    <node concept="3w_OXm" id="5Tr1VsJMIDq" role="2OqNvi" />
-                  </node>
-                </node>
-                <node concept="3cpWs8" id="5Tr1VsJMh0F" role="3cqZAp">
-                  <node concept="3cpWsn" id="5Tr1VsJMh0I" role="3cpWs9">
-                    <property role="TrG5h" value="argString" />
-                    <node concept="17QB3L" id="5Tr1VsJMh0D" role="1tU5fm" />
-                    <node concept="Xl_RD" id="5Tr1VsJMhlC" role="33vP2m">
-                      <property role="Xl_RC" value="" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="1Dw8fO" id="5Tr1VsJMhV$" role="3cqZAp">
-                  <node concept="3clFbS" id="5Tr1VsJMhVA" role="2LFqv$">
-                    <node concept="3clFbJ" id="5Tr1VsJMqIP" role="3cqZAp">
-                      <node concept="3clFbS" id="5Tr1VsJMqIR" role="3clFbx">
-                        <node concept="3clFbF" id="5Tr1VsJMr93" role="3cqZAp">
-                          <node concept="d57v9" id="5Tr1VsJMrBr" role="3clFbG">
-                            <node concept="Xl_RD" id="5Tr1VsJMrFG" role="37vLTx">
-                              <property role="Xl_RC" value=", " />
-                            </node>
-                            <node concept="37vLTw" id="5Tr1VsJMr91" role="37vLTJ">
-                              <ref role="3cqZAo" node="5Tr1VsJMh0I" resolve="argString" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3eOSWO" id="5Tr1VsJMr0h" role="3clFbw">
-                        <node concept="3cmrfG" id="5Tr1VsJMr4C" role="3uHU7w">
-                          <property role="3cmrfH" value="0" />
-                        </node>
-                        <node concept="37vLTw" id="5Tr1VsJMqNa" role="3uHU7B">
-                          <ref role="3cqZAo" node="5Tr1VsJMhVB" resolve="i" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3cpWs8" id="5Tr1VsJNi86" role="3cqZAp">
-                      <node concept="3cpWsn" id="5Tr1VsJNi89" role="3cpWs9">
-                        <property role="TrG5h" value="currPort" />
-                        <node concept="3Tqbb2" id="5Tr1VsJNi84" role="1tU5fm">
-                          <ref role="ehGHo" to="yvgz:6po$YwiVCCi" resolve="DataPort" />
-                        </node>
-                        <node concept="1y4W85" id="5Tr1VsJNmGL" role="33vP2m">
-                          <node concept="37vLTw" id="5Tr1VsJNnGn" role="1y58nS">
-                            <ref role="3cqZAo" node="5Tr1VsJMhVB" resolve="i" />
-                          </node>
-                          <node concept="2OqwBi" id="5Tr1VsJNk9N" role="1y566C">
-                            <node concept="30H73N" id="5Tr1VsJNjGv" role="2Oq$k0" />
-                            <node concept="3Tsc0h" id="5Tr1VsJNkqe" role="2OqNvi">
-                              <ref role="3TtcxE" to="yvgz:3eP8Zudp5G8" resolve="data_ports" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3cpWs8" id="5Tr1VsJMP_w" role="3cqZAp">
-                      <node concept="3cpWsn" id="5Tr1VsJMP_z" role="3cpWs9">
-                        <property role="TrG5h" value="connectedPorts" />
-                        <node concept="2I9FWS" id="5Tr1VsJMQpQ" role="1tU5fm">
-                          <ref role="2I9WkF" to="yvgz:6po$YwiVCCi" resolve="DataPort" />
-                        </node>
-                        <node concept="2OqwBi" id="5Tr1VsJMRow" role="33vP2m">
-                          <node concept="37vLTw" id="5Tr1VsJMRdY" role="2Oq$k0">
-                            <ref role="3cqZAo" node="5Tr1VsJMGfh" resolve="parent" />
-                          </node>
-                          <node concept="2qgKlT" id="5Tr1VsJMRvX" role="2OqNvi">
-                            <ref role="37wK5l" to="ixp9:1Fy8yZq9o69" resolve="findConnectedDataPorts" />
-                            <node concept="37vLTw" id="5Tr1VsJNotc" role="37wK5m">
-                              <ref role="3cqZAo" node="5Tr1VsJNi89" resolve="currPort" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbJ" id="5Tr1VsJMwV2" role="3cqZAp">
-                      <node concept="3clFbS" id="5Tr1VsJMwV4" role="3clFbx">
-                        <node concept="3cpWs8" id="5Tr1VsJN8Kr" role="3cqZAp">
-                          <node concept="3cpWsn" id="5Tr1VsJN8Ku" role="3cpWs9">
-                            <property role="TrG5h" value="errString" />
-                            <node concept="17QB3L" id="5Tr1VsJN8Kp" role="1tU5fm" />
-                            <node concept="3cpWs3" id="5Tr1VsJNfaA" role="33vP2m">
-                              <node concept="3cpWs3" id="5Tr1VsJNdQz" role="3uHU7B">
-                                <node concept="3cpWs3" id="5Tr1VsJNgHy" role="3uHU7B">
-                                  <node concept="3cpWs3" id="5Tr1VsJNq08" role="3uHU7B">
-                                    <node concept="Xl_RD" id="5Tr1VsJNhG2" role="3uHU7B">
-                                      <property role="Xl_RC" value="port '" />
-                                    </node>
-                                    <node concept="2OqwBi" id="5Tr1VsJNqpg" role="3uHU7w">
-                                      <node concept="37vLTw" id="5Tr1VsJNq9h" role="2Oq$k0">
-                                        <ref role="3cqZAo" node="5Tr1VsJNi89" resolve="currPort" />
-                                      </node>
-                                      <node concept="3TrcHB" id="5Tr1VsJNqFN" role="2OqNvi">
-                                        <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                  <node concept="Xl_RD" id="5Tr1VsJNa6l" role="3uHU7w">
-                                    <property role="Xl_RC" value="' of function '" />
-                                  </node>
-                                </node>
-                                <node concept="2OqwBi" id="5Tr1VsJNes3" role="3uHU7w">
-                                  <node concept="30H73N" id="5Tr1VsJNdZg" role="2Oq$k0" />
-                                  <node concept="3TrcHB" id="5Tr1VsJNeCE" role="2OqNvi">
-                                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="Xl_RD" id="5Tr1VsJNgrw" role="3uHU7w">
-                                <property role="Xl_RC" value="' is not connected to exactly 1 other DataPort" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="RRSsy" id="5Tr1VsJN7Ex" role="3cqZAp">
-                          <property role="RRSoG" value="gZ5fh_4/error" />
-                          <node concept="37vLTw" id="5Tr1VsJNc3q" role="RRSoy">
-                            <ref role="3cqZAo" node="5Tr1VsJN8Ku" resolve="errString" />
-                          </node>
-                          <node concept="2ShNRf" id="5Tr1VsJNcbz" role="RRSow">
-                            <node concept="1pGfFk" id="5Tr1VsJNcqj" role="2ShVmc">
-                              <ref role="37wK5l" to="wyt6:~RuntimeException.&lt;init&gt;(java.lang.String)" resolve="RuntimeException" />
-                              <node concept="37vLTw" id="5Tr1VsJNdlZ" role="37wK5m">
-                                <ref role="3cqZAo" node="5Tr1VsJN8Ku" resolve="errString" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3y3z36" id="5Tr1VsJN6$L" role="3clFbw">
-                        <node concept="3cmrfG" id="5Tr1VsJN7yw" role="3uHU7w">
-                          <property role="3cmrfH" value="1" />
-                        </node>
-                        <node concept="2OqwBi" id="5Tr1VsJN3aD" role="3uHU7B">
-                          <node concept="37vLTw" id="5Tr1VsJN0Hu" role="2Oq$k0">
-                            <ref role="3cqZAo" node="5Tr1VsJMP_z" resolve="connectedPorts" />
-                          </node>
-                          <node concept="34oBXx" id="5Tr1VsJN5gO" role="2OqNvi" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbJ" id="5Tr1VsJNxpR" role="3cqZAp">
-                      <node concept="3clFbS" id="5Tr1VsJNxpT" role="3clFbx">
-                        <node concept="3clFbH" id="5Tr1VsJNxpS" role="3cqZAp" />
-                      </node>
-                      <node concept="2OqwBi" id="5Tr1VsJNBTe" role="3clFbw">
-                        <node concept="2OqwBi" id="5Tr1VsJNBg8" role="2Oq$k0">
-                          <node concept="2OqwBi" id="5Tr1VsJNzQQ" role="2Oq$k0">
-                            <node concept="37vLTw" id="5Tr1VsJNx$p" role="2Oq$k0">
-                              <ref role="3cqZAo" node="5Tr1VsJMP_z" resolve="connectedPorts" />
-                            </node>
-                            <node concept="1uHKPH" id="5Tr1VsJN_K1" role="2OqNvi" />
-                          </node>
-                          <node concept="3TrcHB" id="5Tr1VsJNB_o" role="2OqNvi">
-                            <ref role="3TsBF5" to="yvgz:6po$YwiVCCu" resolve="direction" />
-                          </node>
-                        </node>
-                        <node concept="21noJN" id="5Tr1VsJNCaV" role="2OqNvi">
-                          <node concept="21nZrQ" id="5Tr1VsJNJGk" role="21noJM">
-                            <ref role="21nZrZ" to="yvgz:6po$YwiVCCn" resolve="Out" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbF" id="5Tr1VsJNL1d" role="3cqZAp">
-                      <node concept="d57v9" id="5Tr1VsJNMw0" role="3clFbG">
-                        <node concept="2OqwBi" id="5Tr1VsJNSo_" role="37vLTx">
-                          <node concept="2OqwBi" id="5Tr1VsJNOU7" role="2Oq$k0">
-                            <node concept="37vLTw" id="5Tr1VsJNMGJ" role="2Oq$k0">
-                              <ref role="3cqZAo" node="5Tr1VsJMP_z" resolve="connectedPorts" />
-                            </node>
-                            <node concept="1uHKPH" id="5Tr1VsJNQLU" role="2OqNvi" />
-                          </node>
-                          <node concept="3TrcHB" id="5Tr1VsJNSSY" role="2OqNvi">
-                            <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                          </node>
-                        </node>
-                        <node concept="37vLTw" id="5Tr1VsJNL1b" role="37vLTJ">
-                          <ref role="3cqZAo" node="5Tr1VsJMh0I" resolve="argString" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3cpWsn" id="5Tr1VsJMhVB" role="1Duv9x">
-                    <property role="TrG5h" value="i" />
-                    <node concept="10Oyi0" id="5Tr1VsJMi1T" role="1tU5fm" />
-                    <node concept="3cmrfG" id="5Tr1VsJMiaN" role="33vP2m">
-                      <property role="3cmrfH" value="0" />
-                    </node>
-                  </node>
-                  <node concept="3eOVzh" id="5Tr1VsJMjif" role="1Dwp0S">
-                    <node concept="37vLTw" id="5Tr1VsJMimo" role="3uHU7B">
-                      <ref role="3cqZAo" node="5Tr1VsJMhVB" resolve="i" />
-                    </node>
-                    <node concept="2OqwBi" id="5Tr1VsJMnq1" role="3uHU7w">
-                      <node concept="2OqwBi" id="5Tr1VsJMksH" role="2Oq$k0">
-                        <node concept="30H73N" id="5Tr1VsJMjWf" role="2Oq$k0" />
-                        <node concept="3Tsc0h" id="5Tr1VsJMkJx" role="2OqNvi">
-                          <ref role="3TtcxE" to="yvgz:3eP8Zudp5G8" resolve="data_ports" />
-                        </node>
-                      </node>
-                      <node concept="34oBXx" id="5Tr1VsJMpsD" role="2OqNvi" />
-                    </node>
-                  </node>
-                  <node concept="3uNrnE" id="5Tr1VsJMqxV" role="1Dwrff">
-                    <node concept="37vLTw" id="5Tr1VsJMqxX" role="2$L3a6">
-                      <ref role="3cqZAo" node="5Tr1VsJMhVB" resolve="i" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbF" id="Ho3faVHQ3h" role="3cqZAp">
-                  <node concept="37vLTw" id="5Tr1VsJMhFu" role="3clFbG">
-                    <ref role="3cqZAo" node="5Tr1VsJMh0I" resolve="argString" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="356sEF" id="5Tr1VsJMgP8" role="356sEH">
-          <property role="TrG5h" value=")" />
+          <property role="TrG5h" value="params" />
+          <node concept="5jKBG" id="1SzGUGPLmh" role="lGtFl">
+            <ref role="v9R2y" node="5Tr1VsJNE2J" resolve="include_FunctionCallParams" />
+          </node>
         </node>
       </node>
       <node concept="raruj" id="5Tr1VsJEoGu" role="lGtFl" />
@@ -1385,6 +1069,129 @@
     <property role="TrG5h" value="include_FunctionCallParams" />
     <ref role="3gUMe" to="yvgz:3eP8Zudp5G4" resolve="FunctionBlock" />
     <node concept="356WMU" id="5Tr1VsJNE2L" role="13RCb5">
+      <node concept="356sEK" id="1SzGUGPGMf" role="383Ya9">
+        <node concept="356sEF" id="1SzGUGPGMg" role="356sEH">
+          <property role="TrG5h" value="(" />
+        </node>
+        <node concept="356sEF" id="44Cv2OMCeyC" role="356sEH">
+          <property role="TrG5h" value="params" />
+          <node concept="1WS0z7" id="44Cv2OMCjL5" role="lGtFl">
+            <property role="1qytDF" value="portIndex" />
+            <node concept="3JmXsc" id="44Cv2OMCjL6" role="3Jn$fo">
+              <node concept="3clFbS" id="44Cv2OMCjL7" role="2VODD2">
+                <node concept="3clFbF" id="44Cv2OMCjNR" role="3cqZAp">
+                  <node concept="2OqwBi" id="44Cv2OMCk10" role="3clFbG">
+                    <node concept="30H73N" id="44Cv2OMCjNQ" role="2Oq$k0" />
+                    <node concept="3Tsc0h" id="44Cv2OMCkfS" role="2OqNvi">
+                      <ref role="3TtcxE" to="yvgz:3eP8Zudp5G8" resolve="data_ports" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="17Uvod" id="44Cv2OMCksr" role="lGtFl">
+            <property role="2qtEX9" value="name" />
+            <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+            <node concept="3zFVjK" id="44Cv2OMCkss" role="3zH0cK">
+              <node concept="3clFbS" id="44Cv2OMCkst" role="2VODD2">
+                <node concept="3cpWs8" id="44Cv2OMCky6" role="3cqZAp">
+                  <node concept="3cpWsn" id="44Cv2OMCky9" role="3cpWs9">
+                    <property role="TrG5h" value="paramString" />
+                    <node concept="17QB3L" id="44Cv2OMCky5" role="1tU5fm" />
+                    <node concept="Xl_RD" id="44Cv2OMCk$2" role="33vP2m">
+                      <property role="Xl_RC" value="" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="44Cv2OMCkDZ" role="3cqZAp">
+                  <node concept="3clFbS" id="44Cv2OMCkE1" role="3clFbx">
+                    <node concept="3clFbF" id="44Cv2OMCmj$" role="3cqZAp">
+                      <node concept="d57v9" id="44Cv2OMCmEm" role="3clFbG">
+                        <node concept="Xl_RD" id="44Cv2OMCmKz" role="37vLTx">
+                          <property role="Xl_RC" value=", " />
+                        </node>
+                        <node concept="37vLTw" id="44Cv2OMCmjy" role="37vLTJ">
+                          <ref role="3cqZAo" node="44Cv2OMCky9" resolve="paramString" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3eOSWO" id="44Cv2OMCmci" role="3clFbw">
+                    <node concept="3cmrfG" id="44Cv2OMCmdl" role="3uHU7w">
+                      <property role="3cmrfH" value="0" />
+                    </node>
+                    <node concept="2OqwBi" id="44Cv2OMCl8A" role="3uHU7B">
+                      <node concept="1iwH7S" id="44Cv2OMCkEP" role="2Oq$k0" />
+                      <node concept="1qCSth" id="44Cv2OMClmx" role="2OqNvi">
+                        <property role="1qCSqd" value="portIndex" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="44Cv2OMCq4w" role="3cqZAp">
+                  <node concept="3cpWsn" id="44Cv2OMCq4z" role="3cpWs9">
+                    <property role="TrG5h" value="connectedPort" />
+                    <node concept="3Tqbb2" id="44Cv2OMCq4u" role="1tU5fm">
+                      <ref role="ehGHo" to="yvgz:6po$YwiVCCi" resolve="DataPort" />
+                    </node>
+                    <node concept="2OqwBi" id="44Cv2OMCqUD" role="33vP2m">
+                      <node concept="30H73N" id="44Cv2OMCqxB" role="2Oq$k0" />
+                      <node concept="2qgKlT" id="44Cv2OMCruC" role="2OqNvi">
+                        <ref role="37wK5l" to="ixp9:2FsRs4zDsXN" resolve="getPortRecursive" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="44Cv2OMCrOK" role="3cqZAp">
+                  <node concept="3clFbS" id="44Cv2OMCrOM" role="3clFbx">
+                    <node concept="3clFbH" id="44Cv2OMCrOL" role="3cqZAp" />
+                  </node>
+                  <node concept="2OqwBi" id="44Cv2OMCsVu" role="3clFbw">
+                    <node concept="2OqwBi" id="44Cv2OMCsi5" role="2Oq$k0">
+                      <node concept="37vLTw" id="44Cv2OMCrRy" role="2Oq$k0">
+                        <ref role="3cqZAo" node="44Cv2OMCq4z" resolve="connectedPort" />
+                      </node>
+                      <node concept="3TrcHB" id="44Cv2OMCsAf" role="2OqNvi">
+                        <ref role="3TsBF5" to="yvgz:6po$YwiVCCu" resolve="direction" />
+                      </node>
+                    </node>
+                    <node concept="21noJN" id="44Cv2OMCt4H" role="2OqNvi">
+                      <node concept="21nZrQ" id="44Cv2OMCJMq" role="21noJM">
+                        <ref role="21nZrZ" to="yvgz:6po$YwiVCCm" resolve="In" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="44Cv2OMCnP6" role="3cqZAp">
+                  <node concept="d57v9" id="44Cv2OMCoEs" role="3clFbG">
+                    <node concept="37vLTw" id="44Cv2OMCoXR" role="37vLTJ">
+                      <ref role="3cqZAo" node="44Cv2OMCky9" resolve="paramString" />
+                    </node>
+                    <node concept="2OqwBi" id="44Cv2OMCo8g" role="37vLTx">
+                      <node concept="2qgKlT" id="44Cv2OMCor8" role="2OqNvi">
+                        <ref role="37wK5l" to="ixp9:7VOfr8WpcKN" resolve="getVariableName" />
+                      </node>
+                      <node concept="37vLTw" id="44Cv2OMCrFJ" role="2Oq$k0">
+                        <ref role="3cqZAo" node="44Cv2OMCq4z" resolve="connectedPort" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="44Cv2OMCkDa" role="3cqZAp">
+                  <node concept="37vLTw" id="44Cv2OMCkD8" role="3clFbG">
+                    <ref role="3cqZAo" node="44Cv2OMCky9" resolve="paramString" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="356sEF" id="1SzGUGPGMo" role="356sEH">
+          <property role="TrG5h" value=")" />
+        </node>
+        <node concept="2EixSi" id="1SzGUGPGMh" role="2EinRH" />
+      </node>
       <node concept="raruj" id="5Tr1VsJNE2N" role="lGtFl" />
     </node>
   </node>

--- a/languages/Algorithm_CGenerator/generator/templates/main@generator.mps
+++ b/languages/Algorithm_CGenerator/generator/templates/main@generator.mps
@@ -9,9 +9,9 @@
     <import index="5u88" ref="r:4752c29d-6163-4693-b1d7-3c8befc060cd(com.dslfoundry.plaintextgen.textGen)" />
     <import index="yvgz" ref="r:3b411c10-569a-4299-9505-176144359d3b(Algorithm.structure)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
-    <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
     <import index="ixp9" ref="r:172690fd-5286-4218-b525-cadaaf47af22(Algorithm.behavior)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+    <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -21,6 +21,7 @@
       </concept>
       <concept id="1215695189714" name="jetbrains.mps.baseLanguage.structure.PlusAssignmentExpression" flags="nn" index="d57v9" />
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -34,6 +35,7 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
@@ -66,6 +68,9 @@
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
+        <child id="1079359253376" name="expression" index="1eOMHV" />
+      </concept>
       <concept id="1081506762703" name="jetbrains.mps.baseLanguage.structure.GreaterThanExpression" flags="nn" index="3eOSWO" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
@@ -183,6 +188,9 @@
         <child id="1145567471833" name="createdType" index="2T96Bj" />
       </concept>
       <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
+      <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
+        <child id="1177027386292" name="conceptArgument" index="cj9EA" />
+      </concept>
       <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
       <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI">
         <property id="1238684351431" name="asCast" index="1BlNFB" />
@@ -223,6 +231,7 @@
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
+      <concept id="1175845471038" name="jetbrains.mps.baseLanguage.collections.structure.ReverseOperation" flags="nn" index="35Qw8J" />
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
     </language>
   </registry>
@@ -233,11 +242,52 @@
       <ref role="30HIoZ" to="yvgz:7YUYw4xHlaz" resolve="FunctionBlockContainer" />
       <ref role="3lhOvi" node="5Tr1VsJDsug" resolve="function_name" />
     </node>
+    <node concept="3lhOvk" id="44Cv2OMJcBk" role="3lj3bC">
+      <ref role="30HIoZ" to="yvgz:7YUYw4xHlaz" resolve="FunctionBlockContainer" />
+      <ref role="3lhOvi" node="44Cv2OMJcBn" resolve="function_name" />
+    </node>
   </node>
   <node concept="356sEV" id="5Tr1VsJDsug">
     <property role="3Le9LX" value=".c" />
     <property role="TrG5h" value="function_name" />
     <node concept="356WMU" id="5Tr1VsJDsuh" role="356KY_">
+      <node concept="356sEK" id="44Cv2OMJA0j" role="383Ya9">
+        <node concept="356sEF" id="44Cv2OMJAIg" role="356sEH">
+          <property role="TrG5h" value="#include " />
+        </node>
+        <node concept="356sEF" id="44Cv2OMJB3I" role="356sEH">
+          <property role="TrG5h" value="&quot;" />
+        </node>
+        <node concept="356sEF" id="44Cv2OMJAIi" role="356sEH">
+          <property role="TrG5h" value="function_name" />
+          <node concept="17Uvod" id="44Cv2OMJAIp" role="lGtFl">
+            <property role="2qtEX9" value="name" />
+            <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+            <node concept="3zFVjK" id="44Cv2OMJAIq" role="3zH0cK">
+              <node concept="3clFbS" id="44Cv2OMJAIr" role="2VODD2">
+                <node concept="3clFbF" id="44Cv2OMJAN2" role="3cqZAp">
+                  <node concept="2OqwBi" id="44Cv2OMJATS" role="3clFbG">
+                    <node concept="30H73N" id="44Cv2OMJAN1" role="2Oq$k0" />
+                    <node concept="3TrcHB" id="44Cv2OMJAVp" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="356sEF" id="44Cv2OMJAIl" role="356sEH">
+          <property role="TrG5h" value=".h" />
+        </node>
+        <node concept="2EixSi" id="44Cv2OMJA0l" role="2EinRH" />
+        <node concept="356sEF" id="44Cv2OMJBb7" role="356sEH">
+          <property role="TrG5h" value="&quot;" />
+        </node>
+      </node>
+      <node concept="356sEK" id="44Cv2OMJAbC" role="383Ya9">
+        <node concept="2EixSi" id="44Cv2OMJAbE" role="2EinRH" />
+      </node>
       <node concept="356sEK" id="5Tr1VsJDuaY" role="383Ya9">
         <node concept="356sEF" id="5Tr1VsJDuaZ" role="356sEH">
           <property role="TrG5h" value="/* define used functions */" />
@@ -247,9 +297,6 @@
       <node concept="356sEK" id="5Tr1VsJFXTA" role="383Ya9">
         <node concept="356sEF" id="5Tr1VsJFXTB" role="356sEH">
           <property role="TrG5h" value="void functionDef()" />
-          <node concept="1sPUBX" id="5Tr1VsJKruK" role="lGtFl">
-            <ref role="v9R2y" node="5Tr1VsJKqPb" resolve="switch_FunctionDef" />
-          </node>
         </node>
         <node concept="2EixSi" id="5Tr1VsJFXTC" role="2EinRH" />
         <node concept="1WS0z7" id="5Tr1VsJFY0H" role="lGtFl">
@@ -265,6 +312,9 @@
               </node>
             </node>
           </node>
+        </node>
+        <node concept="1sPUBX" id="44Cv2OMJ4Ui" role="lGtFl">
+          <ref role="v9R2y" node="5Tr1VsJKqPb" resolve="switch_FunctionDef" />
         </node>
       </node>
       <node concept="356sEK" id="5Tr1VsJD$ML" role="383Ya9">
@@ -319,97 +369,18 @@
               <property role="TrG5h" value="/* data blocks */" />
             </node>
           </node>
-          <node concept="356sEK" id="5Tr1VsJKyr3" role="383Ya9">
-            <node concept="356sEF" id="5Tr1VsJKyr4" role="356sEH">
-              <property role="TrG5h" value="type" />
-              <node concept="17Uvod" id="5Tr1VsJKBGO" role="lGtFl">
-                <property role="2qtEX9" value="name" />
-                <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
-                <node concept="3zFVjK" id="5Tr1VsJKBGP" role="3zH0cK">
-                  <node concept="3clFbS" id="5Tr1VsJKBGQ" role="2VODD2">
-                    <node concept="3clFbF" id="5Tr1VsJKBLt" role="3cqZAp">
-                      <node concept="2OqwBi" id="5Tr1VsJKCuA" role="3clFbG">
-                        <node concept="2OqwBi" id="5Tr1VsJKBZ2" role="2Oq$k0">
-                          <node concept="30H73N" id="5Tr1VsJKBLs" role="2Oq$k0" />
-                          <node concept="3TrEf2" id="5Tr1VsJKCd1" role="2OqNvi">
-                            <ref role="3Tt5mk" to="yvgz:6po$YwiVDtx" resolve="type" />
-                          </node>
-                        </node>
-                        <node concept="2qgKlT" id="5Tr1VsJKCEV" role="2OqNvi">
-                          <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
+          <node concept="356sEK" id="5QQcZL$IqyF" role="383Ya9">
+            <node concept="356sEF" id="5QQcZL$IqyG" role="356sEH">
+              <property role="TrG5h" value="type name" />
             </node>
-            <node concept="356sEF" id="5Tr1VsJK$bG" role="356sEH">
-              <property role="TrG5h" value=" " />
-            </node>
-            <node concept="356sEF" id="5Tr1VsJK$bD" role="356sEH">
-              <property role="TrG5h" value="name" />
-              <node concept="17Uvod" id="5Tr1VsJKEoQ" role="lGtFl">
-                <property role="2qtEX9" value="name" />
-                <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
-                <node concept="3zFVjK" id="5Tr1VsJKEoR" role="3zH0cK">
-                  <node concept="3clFbS" id="5Tr1VsJKEoS" role="2VODD2">
-                    <node concept="3cpWs8" id="5Tr1VsJKMJ6" role="3cqZAp">
-                      <node concept="3cpWsn" id="5Tr1VsJKMJ9" role="3cpWs9">
-                        <property role="TrG5h" value="dataBlock" />
-                        <node concept="3Tqbb2" id="5Tr1VsJKMJ4" role="1tU5fm">
-                          <ref role="ehGHo" to="yvgz:29RmJoXeePk" resolve="DataBlock" />
-                        </node>
-                        <node concept="1PxgMI" id="5Tr1VsJKNA4" role="33vP2m">
-                          <property role="1BlNFB" value="true" />
-                          <node concept="chp4Y" id="5Tr1VsJKNCs" role="3oSUPX">
-                            <ref role="cht4Q" to="yvgz:29RmJoXeePk" resolve="DataBlock" />
-                          </node>
-                          <node concept="2OqwBi" id="5Tr1VsJKN4K" role="1m5AlR">
-                            <node concept="30H73N" id="5Tr1VsJKMQt" role="2Oq$k0" />
-                            <node concept="1mfA1w" id="5Tr1VsJKNs4" role="2OqNvi" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbF" id="5Tr1VsJKEtv" role="3cqZAp">
-                      <node concept="3cpWs3" id="5Tr1VsJKNSB" role="3clFbG">
-                        <node concept="3cpWs3" id="5Tr1VsJKOfS" role="3uHU7B">
-                          <node concept="2OqwBi" id="5Tr1VsJKOCj" role="3uHU7B">
-                            <node concept="37vLTw" id="5Tr1VsJKOia" role="2Oq$k0">
-                              <ref role="3cqZAo" node="5Tr1VsJKMJ9" resolve="dataBlock" />
-                            </node>
-                            <node concept="3TrcHB" id="5Tr1VsJKOOi" role="2OqNvi">
-                              <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                            </node>
-                          </node>
-                          <node concept="Xl_RD" id="5Tr1VsJKO2L" role="3uHU7w">
-                            <property role="Xl_RC" value="_" />
-                          </node>
-                        </node>
-                        <node concept="2OqwBi" id="5Tr1VsJKEDa" role="3uHU7w">
-                          <node concept="30H73N" id="5Tr1VsJKEtu" role="2Oq$k0" />
-                          <node concept="3TrcHB" id="5Tr1VsJKETn" role="2OqNvi">
-                            <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="356sEF" id="5Tr1VsJK$bK" role="356sEH">
-              <property role="TrG5h" value=";" />
-            </node>
-            <node concept="2EixSi" id="5Tr1VsJKyr5" role="2EinRH" />
-            <node concept="1WS0z7" id="5Tr1VsJK$bR" role="lGtFl">
-              <node concept="3JmXsc" id="5Tr1VsJK$bS" role="3Jn$fo">
-                <node concept="3clFbS" id="5Tr1VsJK$bT" role="2VODD2">
-                  <node concept="3clFbF" id="5Tr1VsJK$eD" role="3cqZAp">
-                    <node concept="2OqwBi" id="5Tr1VsJK$qY" role="3clFbG">
-                      <node concept="30H73N" id="5Tr1VsJK$eC" role="2Oq$k0" />
-                      <node concept="3Tsc0h" id="5Tr1VsJK$yN" role="2OqNvi">
+            <node concept="2EixSi" id="5QQcZL$IqyH" role="2EinRH" />
+            <node concept="1WS0z7" id="5QQcZL$IqCN" role="lGtFl">
+              <node concept="3JmXsc" id="5QQcZL$IqCO" role="3Jn$fo">
+                <node concept="3clFbS" id="5QQcZL$IqCP" role="2VODD2">
+                  <node concept="3clFbF" id="5QQcZL$IqDn" role="3cqZAp">
+                    <node concept="2OqwBi" id="5QQcZL$IqS4" role="3clFbG">
+                      <node concept="30H73N" id="5QQcZL$IqDm" role="2Oq$k0" />
+                      <node concept="3Tsc0h" id="5QQcZL$Ir5m" role="2OqNvi">
                         <ref role="3TtcxE" to="yvgz:4iWYoaWUTsk" resolve="data_blocks" />
                       </node>
                     </node>
@@ -417,23 +388,12 @@
                 </node>
               </node>
             </node>
-            <node concept="1WS0z7" id="5Tr1VsJKAOw" role="lGtFl">
-              <node concept="3JmXsc" id="5Tr1VsJKAOx" role="3Jn$fo">
-                <node concept="3clFbS" id="5Tr1VsJKAOy" role="2VODD2">
-                  <node concept="3clFbF" id="5Tr1VsJKAQ6" role="3cqZAp">
-                    <node concept="2OqwBi" id="5Tr1VsJKB3O" role="3clFbG">
-                      <node concept="30H73N" id="5Tr1VsJKAQ5" role="2Oq$k0" />
-                      <node concept="3Tsc0h" id="5Tr1VsJKBub" role="2OqNvi">
-                        <ref role="3TtcxE" to="yvgz:6jvQBgXExiw" resolve="ports" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
+            <node concept="1sPUBX" id="5QQcZL$Irkj" role="lGtFl">
+              <ref role="v9R2y" node="5QQcZL$HVDQ" resolve="switch_DataBlockVarDeclare" />
             </node>
           </node>
-          <node concept="356sEK" id="5Tr1VsJD_bz" role="383Ya9">
-            <node concept="2EixSi" id="5Tr1VsJD_b_" role="2EinRH" />
+          <node concept="356sEK" id="5QQcZL$I9pQ" role="383Ya9">
+            <node concept="2EixSi" id="5QQcZL$I9pS" role="2EinRH" />
           </node>
           <node concept="356sEK" id="5Tr1VsJDDFr" role="383Ya9">
             <node concept="356sEF" id="5Tr1VsJDDFs" role="356sEH">
@@ -1193,6 +1153,556 @@
         <node concept="2EixSi" id="1SzGUGPGMh" role="2EinRH" />
       </node>
       <node concept="raruj" id="5Tr1VsJNE2N" role="lGtFl" />
+    </node>
+  </node>
+  <node concept="356sEV" id="44Cv2OMJcBn">
+    <property role="TrG5h" value="function_name" />
+    <property role="3Le9LX" value=".h" />
+    <node concept="356WMU" id="44Cv2OMJcBo" role="356KY_">
+      <node concept="356sEK" id="44Cv2OMJqNZ" role="383Ya9">
+        <node concept="356sEF" id="44Cv2OMJqO0" role="356sEH">
+          <property role="TrG5h" value="#ifndef " />
+        </node>
+        <node concept="2EixSi" id="44Cv2OMJqO1" role="2EinRH" />
+        <node concept="356sEF" id="44Cv2OMJqO5" role="356sEH">
+          <property role="TrG5h" value="FILE_NAME" />
+          <node concept="17Uvod" id="44Cv2OMJqP3" role="lGtFl">
+            <property role="2qtEX9" value="name" />
+            <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+            <node concept="3zFVjK" id="44Cv2OMJqP4" role="3zH0cK">
+              <node concept="3clFbS" id="44Cv2OMJqP5" role="2VODD2">
+                <node concept="3clFbF" id="44Cv2OMJqTG" role="3cqZAp">
+                  <node concept="2OqwBi" id="44Cv2OMJrr$" role="3clFbG">
+                    <node concept="2OqwBi" id="44Cv2OMJr0y" role="2Oq$k0">
+                      <node concept="30H73N" id="44Cv2OMJqTF" role="2Oq$k0" />
+                      <node concept="3TrcHB" id="44Cv2OMJr6g" role="2OqNvi">
+                        <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="44Cv2OMJrFb" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~String.toUpperCase()" resolve="toUpperCase" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="356sEF" id="44Cv2OMJrPx" role="356sEH">
+          <property role="TrG5h" value="_H" />
+        </node>
+      </node>
+      <node concept="356sEK" id="44Cv2OMJqOk" role="383Ya9">
+        <node concept="356sEF" id="44Cv2OMJqOl" role="356sEH">
+          <property role="TrG5h" value="#define " />
+        </node>
+        <node concept="356sEF" id="44Cv2OMJqOu" role="356sEH">
+          <property role="TrG5h" value="FILE_NAME" />
+          <node concept="17Uvod" id="44Cv2OMJrQz" role="lGtFl">
+            <property role="2qtEX9" value="name" />
+            <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+            <node concept="3zFVjK" id="44Cv2OMJrQ$" role="3zH0cK">
+              <node concept="3clFbS" id="44Cv2OMJrQ_" role="2VODD2">
+                <node concept="3clFbF" id="44Cv2OMJrVc" role="3cqZAp">
+                  <node concept="2OqwBi" id="44Cv2OMJsp5" role="3clFbG">
+                    <node concept="2OqwBi" id="44Cv2OMJs22" role="2Oq$k0">
+                      <node concept="30H73N" id="44Cv2OMJrVb" role="2Oq$k0" />
+                      <node concept="3TrcHB" id="44Cv2OMJs3z" role="2OqNvi">
+                        <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="44Cv2OMJsCU" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~String.toUpperCase()" resolve="toUpperCase" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="356sEF" id="44Cv2OMJrQv" role="356sEH">
+          <property role="TrG5h" value="_H" />
+        </node>
+        <node concept="2EixSi" id="44Cv2OMJqOm" role="2EinRH" />
+      </node>
+      <node concept="356sEK" id="44Cv2OMJqOx" role="383Ya9">
+        <node concept="2EixSi" id="44Cv2OMJqOz" role="2EinRH" />
+      </node>
+      <node concept="356sEK" id="44Cv2OMJ9U_" role="383Ya9">
+        <node concept="356sEF" id="44Cv2OMJ9UA" role="356sEH">
+          <property role="TrG5h" value="/* define structs */" />
+        </node>
+        <node concept="2EixSi" id="44Cv2OMJ9UB" role="2EinRH" />
+      </node>
+      <node concept="356sEK" id="44Cv2OMJaX$" role="383Ya9">
+        <node concept="356sEF" id="44Cv2OMJaX_" role="356sEH">
+          <property role="TrG5h" value="typedef DataBlockName_st {} DataBlockName_t;" />
+        </node>
+        <node concept="2EixSi" id="44Cv2OMJaXA" role="2EinRH" />
+        <node concept="1WS0z7" id="44Cv2OMJcfw" role="lGtFl">
+          <node concept="3JmXsc" id="44Cv2OMJcfx" role="3Jn$fo">
+            <node concept="3clFbS" id="44Cv2OMJcfy" role="2VODD2">
+              <node concept="3clFbF" id="44Cv2OMJcii" role="3cqZAp">
+                <node concept="2OqwBi" id="44Cv2OMJcpx" role="3clFbG">
+                  <node concept="30H73N" id="44Cv2OMJcih" role="2Oq$k0" />
+                  <node concept="3Tsc0h" id="44Cv2OMJcrv" role="2OqNvi">
+                    <ref role="3TtcxE" to="yvgz:4iWYoaWUTsk" resolve="data_blocks" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1WS0z7" id="44Cv2OMKx0B" role="lGtFl">
+          <node concept="3JmXsc" id="44Cv2OMKx0C" role="3Jn$fo">
+            <node concept="3clFbS" id="44Cv2OMKx0D" role="2VODD2">
+              <node concept="3clFbJ" id="44Cv2OMKx5R" role="3cqZAp">
+                <node concept="2OqwBi" id="44Cv2OMKxjM" role="3clFbw">
+                  <node concept="30H73N" id="44Cv2OMKx6w" role="2Oq$k0" />
+                  <node concept="1mIQ4w" id="44Cv2OMKxxR" role="2OqNvi">
+                    <node concept="chp4Y" id="44Cv2OMKx_q" role="cj9EA">
+                      <ref role="cht4Q" to="yvgz:5o1iPWxUm1h" resolve="DataBlockContainer" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbS" id="44Cv2OMKx5T" role="3clFbx">
+                  <node concept="3cpWs6" id="44Cv2OMKxDN" role="3cqZAp">
+                    <node concept="2OqwBi" id="5QQcZL$FuC5" role="3cqZAk">
+                      <node concept="2OqwBi" id="44Cv2OMKyrI" role="2Oq$k0">
+                        <node concept="1eOMI4" id="44Cv2OMKyoL" role="2Oq$k0">
+                          <node concept="1PxgMI" id="44Cv2OMKxZE" role="1eOMHV">
+                            <property role="1BlNFB" value="true" />
+                            <node concept="chp4Y" id="44Cv2OMKy9q" role="3oSUPX">
+                              <ref role="cht4Q" to="yvgz:5o1iPWxUm1h" resolve="DataBlockContainer" />
+                            </node>
+                            <node concept="30H73N" id="44Cv2OMKxMQ" role="1m5AlR" />
+                          </node>
+                        </node>
+                        <node concept="2qgKlT" id="44Cv2OMKyMa" role="2OqNvi">
+                          <ref role="37wK5l" to="ixp9:44Cv2OMJP6B" resolve="getAllDataBlockContainers" />
+                        </node>
+                      </node>
+                      <node concept="35Qw8J" id="5QQcZL$Fxfd" role="2OqNvi" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="44Cv2OMKz2a" role="3cqZAp">
+                <node concept="10Nm6u" id="44Cv2OMKz28" role="3clFbG" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="5jKBG" id="44Cv2OMKz_0" role="lGtFl">
+          <ref role="v9R2y" node="44Cv2OMKz$s" resolve="include_DataBlockContainerDef" />
+        </node>
+      </node>
+      <node concept="356sEK" id="44Cv2OMJas1" role="383Ya9">
+        <node concept="2EixSi" id="44Cv2OMJas3" role="2EinRH" />
+      </node>
+      <node concept="356sEK" id="44Cv2OMJqOJ" role="383Ya9">
+        <node concept="356sEF" id="44Cv2OMJqOK" role="356sEH">
+          <property role="TrG5h" value="#endif" />
+        </node>
+        <node concept="2EixSi" id="44Cv2OMJqOL" role="2EinRH" />
+      </node>
+    </node>
+    <node concept="n94m4" id="44Cv2OMJcBp" role="lGtFl">
+      <ref role="n9lRv" to="yvgz:7YUYw4xHlaz" resolve="FunctionBlockContainer" />
+    </node>
+    <node concept="17Uvod" id="44Cv2OMJkLL" role="lGtFl">
+      <property role="2qtEX9" value="name" />
+      <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+      <node concept="3zFVjK" id="44Cv2OMJkLM" role="3zH0cK">
+        <node concept="3clFbS" id="44Cv2OMJkLN" role="2VODD2">
+          <node concept="3clFbF" id="44Cv2OMJkQr" role="3cqZAp">
+            <node concept="2OqwBi" id="44Cv2OMJkXh" role="3clFbG">
+              <node concept="30H73N" id="44Cv2OMJkQq" role="2Oq$k0" />
+              <node concept="3TrcHB" id="44Cv2OMJkYM" role="2OqNvi">
+                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="13MO4I" id="44Cv2OMKz$s">
+    <property role="TrG5h" value="include_DataBlockContainerDef" />
+    <ref role="3gUMe" to="yvgz:5o1iPWxUm1h" resolve="DataBlockContainer" />
+    <node concept="356WMU" id="44Cv2OMKz$u" role="13RCb5">
+      <node concept="356sEK" id="44Cv2OMLxme" role="383Ya9">
+        <node concept="356sEF" id="44Cv2OMLxmf" role="356sEH">
+          <property role="TrG5h" value="typedef struct " />
+        </node>
+        <node concept="356sEF" id="44Cv2OMLxmk" role="356sEH">
+          <property role="TrG5h" value="name" />
+          <node concept="17Uvod" id="44Cv2OMLxn2" role="lGtFl">
+            <property role="2qtEX9" value="name" />
+            <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+            <node concept="3zFVjK" id="44Cv2OMLxn3" role="3zH0cK">
+              <node concept="3clFbS" id="44Cv2OMLxn4" role="2VODD2">
+                <node concept="3clFbF" id="44Cv2OMLxrF" role="3cqZAp">
+                  <node concept="2OqwBi" id="44Cv2OMLxDZ" role="3clFbG">
+                    <node concept="30H73N" id="44Cv2OMLxrE" role="2Oq$k0" />
+                    <node concept="3TrcHB" id="44Cv2OMLxV1" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="356sEF" id="44Cv2OMLxmn" role="356sEH">
+          <property role="TrG5h" value="_st" />
+        </node>
+        <node concept="356sEF" id="44Cv2OMLxmr" role="356sEH">
+          <property role="TrG5h" value=" {" />
+        </node>
+        <node concept="2EixSi" id="44Cv2OMLxmg" role="2EinRH" />
+      </node>
+      <node concept="356sEQ" id="44Cv2OMLy6M" role="383Ya9">
+        <property role="333NGx" value="  " />
+        <node concept="356sEK" id="44Cv2OMLy51" role="383Ya9">
+          <node concept="356sEF" id="44Cv2OMLy52" role="356sEH">
+            <property role="TrG5h" value="type name" />
+            <node concept="17Uvod" id="44Cv2OMMpPW" role="lGtFl">
+              <property role="2qtEX9" value="name" />
+              <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+              <node concept="3zFVjK" id="44Cv2OMMpPX" role="3zH0cK">
+                <node concept="3clFbS" id="44Cv2OMMpPY" role="2VODD2">
+                  <node concept="3clFbJ" id="44Cv2OMMpU$" role="3cqZAp">
+                    <node concept="2OqwBi" id="44Cv2OMMqer" role="3clFbw">
+                      <node concept="30H73N" id="44Cv2OMMpZi" role="2Oq$k0" />
+                      <node concept="1mIQ4w" id="44Cv2OMMqJm" role="2OqNvi">
+                        <node concept="chp4Y" id="44Cv2OMMqML" role="cj9EA">
+                          <ref role="cht4Q" to="yvgz:5o1iPWxUm1h" resolve="DataBlockContainer" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbS" id="44Cv2OMMpUA" role="3clFbx">
+                      <node concept="3cpWs6" id="44Cv2OMMqR2" role="3cqZAp">
+                        <node concept="3cpWs3" id="44Cv2OMMrWE" role="3cqZAk">
+                          <node concept="2OqwBi" id="44Cv2OMMsga" role="3uHU7w">
+                            <node concept="30H73N" id="44Cv2OMMrZ_" role="2Oq$k0" />
+                            <node concept="3TrcHB" id="44Cv2OMMsEl" role="2OqNvi">
+                              <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                            </node>
+                          </node>
+                          <node concept="3cpWs3" id="44Cv2OMMr_w" role="3uHU7B">
+                            <node concept="2OqwBi" id="44Cv2OMMr3T" role="3uHU7B">
+                              <node concept="30H73N" id="44Cv2OMMqSv" role="2Oq$k0" />
+                              <node concept="3TrcHB" id="44Cv2OMMr7G" role="2OqNvi">
+                                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                              </node>
+                            </node>
+                            <node concept="Xl_RD" id="44Cv2OMMrLw" role="3uHU7w">
+                              <property role="Xl_RC" value="_t " />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cpWs8" id="5QQcZL$FQE8" role="3cqZAp">
+                    <node concept="3cpWsn" id="5QQcZL$FQEb" role="3cpWs9">
+                      <property role="TrG5h" value="memberStr" />
+                      <node concept="17QB3L" id="5QQcZL$FQE6" role="1tU5fm" />
+                      <node concept="Xl_RD" id="5QQcZL$FRhA" role="33vP2m">
+                        <property role="Xl_RC" value="" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="5QQcZL$FL55" role="3cqZAp">
+                    <node concept="2OqwBi" id="5QQcZL$FNGV" role="3clFbG">
+                      <node concept="2OqwBi" id="5QQcZL$FLu2" role="2Oq$k0">
+                        <node concept="30H73N" id="5QQcZL$FL53" role="2Oq$k0" />
+                        <node concept="3Tsc0h" id="5QQcZL$FLO8" role="2OqNvi">
+                          <ref role="3TtcxE" to="yvgz:6jvQBgXExiw" resolve="ports" />
+                        </node>
+                      </node>
+                      <node concept="2es0OD" id="5QQcZL$FPT2" role="2OqNvi">
+                        <node concept="1bVj0M" id="5QQcZL$FPT4" role="23t8la">
+                          <node concept="3clFbS" id="5QQcZL$FPT5" role="1bW5cS">
+                            <node concept="3clFbF" id="5QQcZL$FRAx" role="3cqZAp">
+                              <node concept="d57v9" id="5QQcZL$FSgN" role="3clFbG">
+                                <node concept="3cpWs3" id="5QQcZL$FWMx" role="37vLTx">
+                                  <node concept="Xl_RD" id="5QQcZL$FWT8" role="3uHU7w">
+                                    <property role="Xl_RC" value="; " />
+                                  </node>
+                                  <node concept="3cpWs3" id="5QQcZL$FUiN" role="3uHU7B">
+                                    <node concept="3cpWs3" id="5QQcZL$FTDA" role="3uHU7B">
+                                      <node concept="2OqwBi" id="5QQcZL$FSM_" role="3uHU7B">
+                                        <node concept="37vLTw" id="5QQcZL$FSur" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="5QQcZL$FPT6" resolve="dataPort" />
+                                        </node>
+                                        <node concept="3TrEf2" id="5QQcZL$FT48" role="2OqNvi">
+                                          <ref role="3Tt5mk" to="yvgz:6po$YwiVDtx" resolve="type" />
+                                        </node>
+                                      </node>
+                                      <node concept="Xl_RD" id="5QQcZL$FTJx" role="3uHU7w">
+                                        <property role="Xl_RC" value=" " />
+                                      </node>
+                                    </node>
+                                    <node concept="2OqwBi" id="5QQcZL$FVKk" role="3uHU7w">
+                                      <node concept="37vLTw" id="5QQcZL$FVx9" role="2Oq$k0">
+                                        <ref role="3cqZAo" node="5QQcZL$FPT6" resolve="dataPort" />
+                                      </node>
+                                      <node concept="2qgKlT" id="5QQcZL$FW2c" role="2OqNvi">
+                                        <ref role="37wK5l" to="ixp9:7VOfr8WpcKN" resolve="getVariableName" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="37vLTw" id="5QQcZL$FRAw" role="37vLTJ">
+                                  <ref role="3cqZAo" node="5QQcZL$FQEb" resolve="memberStr" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="Rh6nW" id="5QQcZL$FPT6" role="1bW2Oz">
+                            <property role="TrG5h" value="dataPort" />
+                            <node concept="2jxLKc" id="5QQcZL$FPT7" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="44Cv2OMMsSv" role="3cqZAp">
+                    <node concept="37vLTw" id="5QQcZL$FRv1" role="3clFbG">
+                      <ref role="3cqZAo" node="5QQcZL$FQEb" resolve="memberStr" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="356sEF" id="44Cv2OMLyf3" role="356sEH">
+            <property role="TrG5h" value=";" />
+          </node>
+          <node concept="2EixSi" id="44Cv2OMLy53" role="2EinRH" />
+          <node concept="1WS0z7" id="44Cv2OMLyf8" role="lGtFl">
+            <node concept="3JmXsc" id="44Cv2OMLyf9" role="3Jn$fo">
+              <node concept="3clFbS" id="44Cv2OMLyfa" role="2VODD2">
+                <node concept="3clFbF" id="44Cv2OMLyhU" role="3cqZAp">
+                  <node concept="2OqwBi" id="44Cv2OMLyq9" role="3clFbG">
+                    <node concept="30H73N" id="44Cv2OMLyhT" role="2Oq$k0" />
+                    <node concept="3Tsc0h" id="44Cv2OMLyz7" role="2OqNvi">
+                      <ref role="3TtcxE" to="yvgz:5o1iPWxUm1i" resolve="data_blocks" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="356sEK" id="44Cv2OMLxmE" role="383Ya9">
+        <node concept="356sEF" id="44Cv2OMLxmF" role="356sEH">
+          <property role="TrG5h" value="} " />
+        </node>
+        <node concept="2EixSi" id="44Cv2OMLxmG" role="2EinRH" />
+        <node concept="356sEF" id="44Cv2OMLxmQ" role="356sEH">
+          <property role="TrG5h" value="name" />
+          <node concept="17Uvod" id="44Cv2OMLxYa" role="lGtFl">
+            <property role="2qtEX9" value="name" />
+            <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+            <node concept="3zFVjK" id="44Cv2OMLxYb" role="3zH0cK">
+              <node concept="3clFbS" id="44Cv2OMLxYc" role="2VODD2">
+                <node concept="3clFbF" id="44Cv2OMLxYA" role="3cqZAp">
+                  <node concept="2OqwBi" id="44Cv2OMLxZ5" role="3clFbG">
+                    <node concept="30H73N" id="44Cv2OMLxY_" role="2Oq$k0" />
+                    <node concept="3TrcHB" id="44Cv2OMLxZS" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="356sEF" id="44Cv2OMLxmT" role="356sEH">
+          <property role="TrG5h" value="_t" />
+        </node>
+        <node concept="356sEF" id="44Cv2OMLxmX" role="356sEH">
+          <property role="TrG5h" value=";" />
+        </node>
+      </node>
+      <node concept="356sEK" id="44Cv2OMNEL_" role="383Ya9">
+        <node concept="2EixSi" id="44Cv2OMNELB" role="2EinRH" />
+      </node>
+      <node concept="raruj" id="44Cv2OMKz$w" role="lGtFl" />
+    </node>
+  </node>
+  <node concept="jVnub" id="5QQcZL$HVDQ">
+    <property role="TrG5h" value="switch_DataBlockVarDeclare" />
+    <node concept="3aamgX" id="5QQcZL$HVDT" role="3aUrZf">
+      <property role="36QftV" value="true" />
+      <ref role="30HIoZ" to="yvgz:5o1iPWxUm1h" resolve="DataBlockContainer" />
+      <node concept="gft3U" id="5QQcZL$HVE9" role="1lVwrX">
+        <node concept="356WMU" id="5QQcZL$HVEf" role="gfFT$">
+          <node concept="356sEK" id="5QQcZL$HWj9" role="383Ya9">
+            <node concept="356sEF" id="5QQcZL$HWja" role="356sEH">
+              <property role="TrG5h" value="type" />
+              <node concept="17Uvod" id="5QQcZL$HWjm" role="lGtFl">
+                <property role="2qtEX9" value="name" />
+                <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+                <node concept="3zFVjK" id="5QQcZL$HWjn" role="3zH0cK">
+                  <node concept="3clFbS" id="5QQcZL$HWjo" role="2VODD2">
+                    <node concept="3clFbF" id="5QQcZL$HWnZ" role="3cqZAp">
+                      <node concept="3cpWs3" id="5QQcZL$I0nm" role="3clFbG">
+                        <node concept="Xl_RD" id="5QQcZL$I0oM" role="3uHU7w">
+                          <property role="Xl_RC" value="_t" />
+                        </node>
+                        <node concept="2OqwBi" id="5QQcZL$HWAj" role="3uHU7B">
+                          <node concept="30H73N" id="5QQcZL$HWnY" role="2Oq$k0" />
+                          <node concept="3TrcHB" id="5QQcZL$HWNr" role="2OqNvi">
+                            <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="356sEF" id="5QQcZL$HWjf" role="356sEH">
+              <property role="TrG5h" value=" " />
+            </node>
+            <node concept="356sEF" id="5QQcZL$HWji" role="356sEH">
+              <property role="TrG5h" value="name" />
+              <node concept="17Uvod" id="5QQcZL$HXsj" role="lGtFl">
+                <property role="2qtEX9" value="name" />
+                <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+                <node concept="3zFVjK" id="5QQcZL$HXsk" role="3zH0cK">
+                  <node concept="3clFbS" id="5QQcZL$HXsl" role="2VODD2">
+                    <node concept="3clFbF" id="5QQcZL$HXsJ" role="3cqZAp">
+                      <node concept="2OqwBi" id="5QQcZL$HXF3" role="3clFbG">
+                        <node concept="30H73N" id="5QQcZL$HXsI" role="2Oq$k0" />
+                        <node concept="3TrcHB" id="5QQcZL$HXVR" role="2OqNvi">
+                          <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2EixSi" id="5QQcZL$HWjb" role="2EinRH" />
+            <node concept="356sEF" id="5QQcZL$IakI" role="356sEH">
+              <property role="TrG5h" value=";" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3aamgX" id="5QQcZL$HVEh" role="3aUrZf">
+      <property role="36QftV" value="true" />
+      <ref role="30HIoZ" to="yvgz:29RmJoXeePk" resolve="DataBlock" />
+      <node concept="gft3U" id="5QQcZL$HVEC" role="1lVwrX">
+        <node concept="356WMU" id="5QQcZL$HVEI" role="gfFT$">
+          <node concept="356sEK" id="5QQcZL$HVGa" role="383Ya9">
+            <node concept="356sEF" id="5QQcZL$HVGb" role="356sEH">
+              <property role="TrG5h" value="type" />
+              <node concept="17Uvod" id="5QQcZL$HVGc" role="lGtFl">
+                <property role="2qtEX9" value="name" />
+                <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+                <node concept="3zFVjK" id="5QQcZL$HVGd" role="3zH0cK">
+                  <node concept="3clFbS" id="5QQcZL$HVGe" role="2VODD2">
+                    <node concept="3clFbF" id="5QQcZL$HVGf" role="3cqZAp">
+                      <node concept="2OqwBi" id="5QQcZL$HVGg" role="3clFbG">
+                        <node concept="2OqwBi" id="5QQcZL$HVGh" role="2Oq$k0">
+                          <node concept="30H73N" id="5QQcZL$HVGi" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="5QQcZL$HVGj" role="2OqNvi">
+                            <ref role="3Tt5mk" to="yvgz:6po$YwiVDtx" resolve="type" />
+                          </node>
+                        </node>
+                        <node concept="2qgKlT" id="5QQcZL$HVGk" role="2OqNvi">
+                          <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="356sEF" id="5QQcZL$HVGl" role="356sEH">
+              <property role="TrG5h" value=" " />
+            </node>
+            <node concept="356sEF" id="5QQcZL$HVGm" role="356sEH">
+              <property role="TrG5h" value="name" />
+              <node concept="17Uvod" id="5QQcZL$HVGn" role="lGtFl">
+                <property role="2qtEX9" value="name" />
+                <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+                <node concept="3zFVjK" id="5QQcZL$HVGo" role="3zH0cK">
+                  <node concept="3clFbS" id="5QQcZL$HVGp" role="2VODD2">
+                    <node concept="3cpWs8" id="5QQcZL$HVGq" role="3cqZAp">
+                      <node concept="3cpWsn" id="5QQcZL$HVGr" role="3cpWs9">
+                        <property role="TrG5h" value="dataBlock" />
+                        <node concept="3Tqbb2" id="5QQcZL$HVGs" role="1tU5fm">
+                          <ref role="ehGHo" to="yvgz:29RmJoXeePk" resolve="DataBlock" />
+                        </node>
+                        <node concept="1PxgMI" id="5QQcZL$HVGt" role="33vP2m">
+                          <property role="1BlNFB" value="true" />
+                          <node concept="chp4Y" id="5QQcZL$HVGu" role="3oSUPX">
+                            <ref role="cht4Q" to="yvgz:29RmJoXeePk" resolve="DataBlock" />
+                          </node>
+                          <node concept="2OqwBi" id="5QQcZL$HVGv" role="1m5AlR">
+                            <node concept="30H73N" id="5QQcZL$HVGw" role="2Oq$k0" />
+                            <node concept="1mfA1w" id="5QQcZL$HVGx" role="2OqNvi" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="5QQcZL$HVGy" role="3cqZAp">
+                      <node concept="3cpWs3" id="5QQcZL$HVGz" role="3clFbG">
+                        <node concept="3cpWs3" id="5QQcZL$HVG$" role="3uHU7B">
+                          <node concept="2OqwBi" id="5QQcZL$HVG_" role="3uHU7B">
+                            <node concept="37vLTw" id="5QQcZL$HVGA" role="2Oq$k0">
+                              <ref role="3cqZAo" node="5QQcZL$HVGr" resolve="dataBlock" />
+                            </node>
+                            <node concept="3TrcHB" id="5QQcZL$HVGB" role="2OqNvi">
+                              <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                            </node>
+                          </node>
+                          <node concept="Xl_RD" id="5QQcZL$HVGC" role="3uHU7w">
+                            <property role="Xl_RC" value="_" />
+                          </node>
+                        </node>
+                        <node concept="2OqwBi" id="5QQcZL$HVGD" role="3uHU7w">
+                          <node concept="30H73N" id="5QQcZL$HVGE" role="2Oq$k0" />
+                          <node concept="3TrcHB" id="5QQcZL$HVGF" role="2OqNvi">
+                            <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="356sEF" id="5QQcZL$HVGG" role="356sEH">
+              <property role="TrG5h" value=";" />
+            </node>
+            <node concept="2EixSi" id="5QQcZL$HVGH" role="2EinRH" />
+            <node concept="1WS0z7" id="5QQcZL$HVGI" role="lGtFl">
+              <node concept="3JmXsc" id="5QQcZL$HVGJ" role="3Jn$fo">
+                <node concept="3clFbS" id="5QQcZL$HVGK" role="2VODD2">
+                  <node concept="3clFbF" id="5QQcZL$HVGL" role="3cqZAp">
+                    <node concept="2OqwBi" id="5QQcZL$HVGM" role="3clFbG">
+                      <node concept="30H73N" id="5QQcZL$HVGN" role="2Oq$k0" />
+                      <node concept="3Tsc0h" id="5QQcZL$HVGO" role="2OqNvi">
+                        <ref role="3TtcxE" to="yvgz:6jvQBgXExiw" resolve="ports" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
   </node>
 </model>

--- a/languages/Algorithm_CGenerator/generator/templates/main@generator.mps
+++ b/languages/Algorithm_CGenerator/generator/templates/main@generator.mps
@@ -1,0 +1,1392 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:b9850e82-e887-4d10-9c8c-03f245d17299(main@generator)">
+  <persistence version="9" />
+  <languages>
+    <use id="990507d3-3527-4c54-bfe9-0ca3c9c6247a" name="com.dslfoundry.plaintextgen" version="0" />
+    <devkit ref="a2eb3a43-fcc2-4200-80dc-c60110c4862d(jetbrains.mps.devkit.templates)" />
+  </languages>
+  <imports>
+    <import index="5u88" ref="r:4752c29d-6163-4693-b1d7-3c8befc060cd(com.dslfoundry.plaintextgen.textGen)" />
+    <import index="yvgz" ref="r:3b411c10-569a-4299-9505-176144359d3b(Algorithm.structure)" implicit="true" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+    <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
+    <import index="ixp9" ref="r:172690fd-5286-4218-b525-cadaaf47af22(Algorithm.behavior)" implicit="true" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
+      <concept id="1215695189714" name="jetbrains.mps.baseLanguage.structure.PlusAssignmentExpression" flags="nn" index="d57v9" />
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
+      <concept id="1239714755177" name="jetbrains.mps.baseLanguage.structure.AbstractUnaryNumberOperation" flags="nn" index="2$Kvd9">
+        <child id="1239714902950" name="expression" index="2$L3a6" />
+      </concept>
+      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
+        <child id="1154032183016" name="body" index="2LFqv$" />
+      </concept>
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1081506762703" name="jetbrains.mps.baseLanguage.structure.GreaterThanExpression" flags="nn" index="3eOSWO" />
+      <concept id="1081506773034" name="jetbrains.mps.baseLanguage.structure.LessThanExpression" flags="nn" index="3eOVzh" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="1214918800624" name="jetbrains.mps.baseLanguage.structure.PostfixIncrementExpression" flags="nn" index="3uNrnE" />
+      <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+      <concept id="1144230876926" name="jetbrains.mps.baseLanguage.structure.AbstractForStatement" flags="nn" index="1DupvO">
+        <child id="1144230900587" name="variable" index="1Duv9x" />
+      </concept>
+      <concept id="1144231330558" name="jetbrains.mps.baseLanguage.structure.ForStatement" flags="nn" index="1Dw8fO">
+        <child id="1144231399730" name="condition" index="1Dwp0S" />
+        <child id="1144231408325" name="iteration" index="1Dwrff" />
+      </concept>
+    </language>
+    <language id="b401a680-8325-4110-8fd3-84331ff25bef" name="jetbrains.mps.lang.generator">
+      <concept id="1510949579266781519" name="jetbrains.mps.lang.generator.structure.TemplateCallMacro" flags="ln" index="5jKBG" />
+      <concept id="1095416546421" name="jetbrains.mps.lang.generator.structure.MappingConfiguration" flags="ig" index="bUwia">
+        <child id="1167514678247" name="rootMappingRule" index="3lj3bC" />
+      </concept>
+      <concept id="1177093525992" name="jetbrains.mps.lang.generator.structure.InlineTemplate_RuleConsequence" flags="lg" index="gft3U">
+        <child id="1177093586806" name="templateNode" index="gfFT$" />
+      </concept>
+      <concept id="1168559333462" name="jetbrains.mps.lang.generator.structure.TemplateDeclarationReference" flags="ln" index="j$656" />
+      <concept id="1112730859144" name="jetbrains.mps.lang.generator.structure.TemplateSwitch" flags="ig" index="jVnub">
+        <child id="1167340453568" name="reductionMappingRule" index="3aUrZf" />
+      </concept>
+      <concept id="1168619357332" name="jetbrains.mps.lang.generator.structure.RootTemplateAnnotation" flags="lg" index="n94m4">
+        <reference id="1168619429071" name="applicableConcept" index="n9lRv" />
+      </concept>
+      <concept id="1095672379244" name="jetbrains.mps.lang.generator.structure.TemplateFragment" flags="ng" index="raruj" />
+      <concept id="1722980698497626400" name="jetbrains.mps.lang.generator.structure.ITemplateCall" flags="ng" index="v9R3L">
+        <reference id="1722980698497626483" name="template" index="v9R2y" />
+      </concept>
+      <concept id="1167169188348" name="jetbrains.mps.lang.generator.structure.TemplateFunctionParameter_sourceNode" flags="nn" index="30H73N" />
+      <concept id="1167169308231" name="jetbrains.mps.lang.generator.structure.BaseMappingRule" flags="ng" index="30H$t8">
+        <property id="1167272244852" name="applyToConceptInheritors" index="36QftV" />
+        <reference id="1167169349424" name="applicableConcept" index="30HIoZ" />
+      </concept>
+      <concept id="1092059087312" name="jetbrains.mps.lang.generator.structure.TemplateDeclaration" flags="ig" index="13MO4I">
+        <reference id="1168285871518" name="applicableConcept" index="3gUMe" />
+        <child id="1092060348987" name="contentNode" index="13RCb5" />
+      </concept>
+      <concept id="1087833241328" name="jetbrains.mps.lang.generator.structure.PropertyMacro" flags="ln" index="17Uvod">
+        <child id="1167756362303" name="propertyValueFunction" index="3zH0cK" />
+      </concept>
+      <concept id="1167327847730" name="jetbrains.mps.lang.generator.structure.Reduction_MappingRule" flags="lg" index="3aamgX">
+        <child id="1169672767469" name="ruleConsequence" index="1lVwrX" />
+      </concept>
+      <concept id="1167514355419" name="jetbrains.mps.lang.generator.structure.Root_MappingRule" flags="lg" index="3lhOvk">
+        <reference id="1167514355421" name="template" index="3lhOvi" />
+      </concept>
+      <concept id="982871510068000147" name="jetbrains.mps.lang.generator.structure.TemplateSwitchMacro" flags="lg" index="1sPUBX" />
+      <concept id="1167756080639" name="jetbrains.mps.lang.generator.structure.PropertyMacro_GetPropertyValue" flags="in" index="3zFVjK" />
+      <concept id="1167951910403" name="jetbrains.mps.lang.generator.structure.SourceSubstituteMacro_SourceNodesQuery" flags="in" index="3JmXsc" />
+      <concept id="1118786554307" name="jetbrains.mps.lang.generator.structure.LoopMacro" flags="ln" index="1WS0z7">
+        <property id="7430509679011668804" name="counterVarName" index="1qytDF" />
+        <child id="1167952069335" name="sourceNodesQuery" index="3Jn$fo" />
+      </concept>
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
+    <language id="d7706f63-9be2-479c-a3da-ae92af1e64d5" name="jetbrains.mps.lang.generator.generationContext">
+      <concept id="1216860049635" name="jetbrains.mps.lang.generator.generationContext.structure.TemplateFunctionParameter_generationContext" flags="nn" index="1iwH7S" />
+      <concept id="7430509679014182526" name="jetbrains.mps.lang.generator.generationContext.structure.GenerationContextOp_ContextVarRef" flags="ng" index="1qCSth">
+        <property id="7430509679014182818" name="contextVarName" index="1qCSqd" />
+      </concept>
+    </language>
+    <language id="990507d3-3527-4c54-bfe9-0ca3c9c6247a" name="com.dslfoundry.plaintextgen">
+      <concept id="5082088080656902716" name="com.dslfoundry.plaintextgen.structure.NewlineMarker" flags="ng" index="2EixSi" />
+      <concept id="1145195647825954804" name="com.dslfoundry.plaintextgen.structure.word" flags="ng" index="356sEF" />
+      <concept id="1145195647825954799" name="com.dslfoundry.plaintextgen.structure.Line" flags="ng" index="356sEK">
+        <child id="5082088080656976323" name="newlineMarker" index="2EinRH" />
+        <child id="1145195647825954802" name="words" index="356sEH" />
+      </concept>
+      <concept id="1145195647825954793" name="com.dslfoundry.plaintextgen.structure.SpaceIndentedText" flags="ng" index="356sEQ">
+        <property id="5198309202558919052" name="indent" index="333NGx" />
+      </concept>
+      <concept id="1145195647825954788" name="com.dslfoundry.plaintextgen.structure.TextgenText" flags="ng" index="356sEV">
+        <property id="5407518469085446424" name="ext" index="3Le9LX" />
+        <child id="1145195647826100986" name="content" index="356KY_" />
+      </concept>
+      <concept id="1145195647826084325" name="com.dslfoundry.plaintextgen.structure.VerticalLines" flags="ng" index="356WMU" />
+      <concept id="7214912913997260680" name="com.dslfoundry.plaintextgen.structure.IVerticalGroup" flags="ng" index="383Yap">
+        <child id="7214912913997260696" name="lines" index="383Ya9" />
+      </concept>
+    </language>
+    <language id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging">
+      <concept id="2034914114981261497" name="jetbrains.mps.baseLanguage.logging.structure.LogLowLevelStatement" flags="ng" index="RRSsy">
+        <property id="2034914114981261751" name="severity" index="RRSoG" />
+        <child id="2034914114981261755" name="throwable" index="RRSow" />
+        <child id="2034914114981261753" name="message" index="RRSoy" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="4705942098322609812" name="jetbrains.mps.lang.smodel.structure.EnumMember_IsOperation" flags="ng" index="21noJN">
+        <child id="4705942098322609813" name="member" index="21noJM" />
+      </concept>
+      <concept id="4705942098322467729" name="jetbrains.mps.lang.smodel.structure.EnumMemberReference" flags="ng" index="21nZrQ">
+        <reference id="4705942098322467736" name="decl" index="21nZrZ" />
+      </concept>
+      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
+        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
+      </concept>
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
+        <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
+        <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
+      </concept>
+      <concept id="1145383075378" name="jetbrains.mps.lang.smodel.structure.SNodeListType" flags="in" index="2I9FWS">
+        <reference id="1145383142433" name="elementConcept" index="2I9WkF" />
+      </concept>
+      <concept id="1145567426890" name="jetbrains.mps.lang.smodel.structure.SNodeListCreator" flags="nn" index="2T8Vx0">
+        <child id="1145567471833" name="createdType" index="2T96Bj" />
+      </concept>
+      <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
+      <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
+      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI">
+        <property id="1238684351431" name="asCast" index="1BlNFB" />
+      </concept>
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
+      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
+        <reference id="1138056516764" name="link" index="3Tt5mk" />
+      </concept>
+      <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
+        <reference id="1138056546658" name="link" index="3TtcxE" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="3364660638048049750" name="jetbrains.mps.lang.core.structure.PropertyAttribute" flags="ng" index="A9Btg">
+        <property id="1757699476691236117" name="name_DebugInfo" index="2qtEX9" />
+        <property id="1341860900487648621" name="propertyId" index="P4ACc" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
+        <child id="540871147943773366" name="argument" index="25WWJ7" />
+      </concept>
+      <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
+      <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
+      <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
+      <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
+      <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
+      <concept id="1225711141656" name="jetbrains.mps.baseLanguage.collections.structure.ListElementAccessExpression" flags="nn" index="1y4W85">
+        <child id="1225711182005" name="list" index="1y566C" />
+        <child id="1225711191269" name="index" index="1y58nS" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="bUwia" id="5Tr1VsJDrkr">
+    <property role="TrG5h" value="main" />
+    <node concept="3lhOvk" id="5Tr1VsJDt9h" role="3lj3bC">
+      <ref role="30HIoZ" to="yvgz:7YUYw4xHlaz" resolve="FunctionBlockContainer" />
+      <ref role="3lhOvi" node="5Tr1VsJDsug" resolve="function_name" />
+    </node>
+  </node>
+  <node concept="356sEV" id="5Tr1VsJDsug">
+    <property role="3Le9LX" value=".c" />
+    <property role="TrG5h" value="function_name" />
+    <node concept="356WMU" id="5Tr1VsJDsuh" role="356KY_">
+      <node concept="356sEK" id="5Tr1VsJDuaY" role="383Ya9">
+        <node concept="356sEF" id="5Tr1VsJDuaZ" role="356sEH">
+          <property role="TrG5h" value="/* define used functions */" />
+        </node>
+        <node concept="2EixSi" id="5Tr1VsJDub0" role="2EinRH" />
+      </node>
+      <node concept="356sEK" id="5Tr1VsJFXTA" role="383Ya9">
+        <node concept="356sEF" id="5Tr1VsJFXTB" role="356sEH">
+          <property role="TrG5h" value="void functionDef()" />
+          <node concept="1sPUBX" id="5Tr1VsJKruK" role="lGtFl">
+            <ref role="v9R2y" node="5Tr1VsJKqPb" resolve="switch_FunctionDef" />
+          </node>
+        </node>
+        <node concept="2EixSi" id="5Tr1VsJFXTC" role="2EinRH" />
+        <node concept="1WS0z7" id="5Tr1VsJFY0H" role="lGtFl">
+          <node concept="3JmXsc" id="5Tr1VsJFY0I" role="3Jn$fo">
+            <node concept="3clFbS" id="5Tr1VsJFY0J" role="2VODD2">
+              <node concept="3clFbF" id="5Tr1VsJFY1h" role="3cqZAp">
+                <node concept="2OqwBi" id="5Tr1VsJFYfc" role="3clFbG">
+                  <node concept="30H73N" id="5Tr1VsJFY1g" role="2Oq$k0" />
+                  <node concept="3Tsc0h" id="5Tr1VsJFYs1" role="2OqNvi">
+                    <ref role="3TtcxE" to="yvgz:4iWYoaWUTsf" resolve="function_blocks" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="356sEK" id="5Tr1VsJD$ML" role="383Ya9">
+        <node concept="2EixSi" id="5Tr1VsJD$MN" role="2EinRH" />
+      </node>
+      <node concept="356sEK" id="5Tr1VsJD$P9" role="383Ya9">
+        <node concept="356sEF" id="5Tr1VsJD$Pa" role="356sEH">
+          <property role="TrG5h" value="/* define function container */" />
+        </node>
+        <node concept="2EixSi" id="5Tr1VsJD$Pb" role="2EinRH" />
+      </node>
+      <node concept="356sEK" id="5Tr1VsJD$VS" role="383Ya9">
+        <node concept="356sEF" id="5Tr1VsJNFK7" role="356sEH">
+          <property role="TrG5h" value="void " />
+        </node>
+        <node concept="356sEF" id="5Tr1VsJNFKd" role="356sEH">
+          <property role="TrG5h" value="functionName" />
+          <node concept="17Uvod" id="5Tr1VsJNFKk" role="lGtFl">
+            <property role="2qtEX9" value="name" />
+            <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+            <node concept="3zFVjK" id="5Tr1VsJNFKl" role="3zH0cK">
+              <node concept="3clFbS" id="5Tr1VsJNFKm" role="2VODD2">
+                <node concept="3clFbF" id="5Tr1VsJNFOX" role="3cqZAp">
+                  <node concept="2OqwBi" id="5Tr1VsJNFVF" role="3clFbG">
+                    <node concept="30H73N" id="5Tr1VsJNFOW" role="2Oq$k0" />
+                    <node concept="3TrcHB" id="5Tr1VsJNFX7" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="356sEF" id="5Tr1VsJD$VT" role="356sEH">
+          <property role="TrG5h" value="void functionDef(params)" />
+          <node concept="5jKBG" id="5Tr1VsJM0Xw" role="lGtFl">
+            <ref role="v9R2y" node="5Tr1VsJLpoy" resolve="include_FunctionDefParams" />
+          </node>
+        </node>
+        <node concept="356sEF" id="5Tr1VsJD_2Q" role="356sEH">
+          <property role="TrG5h" value=" {" />
+        </node>
+        <node concept="2EixSi" id="5Tr1VsJD$VU" role="2EinRH" />
+      </node>
+      <node concept="356sEK" id="5Tr1VsJD_9P" role="383Ya9">
+        <node concept="356sEQ" id="5Tr1VsJD_bm" role="356sEH">
+          <property role="333NGx" value="  " />
+          <node concept="356sEK" id="5Tr1VsJD_bj" role="383Ya9">
+            <node concept="2EixSi" id="5Tr1VsJD_bl" role="2EinRH" />
+            <node concept="356sEF" id="5Tr1VsJD_9Q" role="356sEH">
+              <property role="TrG5h" value="/* data blocks */" />
+            </node>
+          </node>
+          <node concept="356sEK" id="5Tr1VsJKyr3" role="383Ya9">
+            <node concept="356sEF" id="5Tr1VsJKyr4" role="356sEH">
+              <property role="TrG5h" value="type" />
+              <node concept="17Uvod" id="5Tr1VsJKBGO" role="lGtFl">
+                <property role="2qtEX9" value="name" />
+                <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+                <node concept="3zFVjK" id="5Tr1VsJKBGP" role="3zH0cK">
+                  <node concept="3clFbS" id="5Tr1VsJKBGQ" role="2VODD2">
+                    <node concept="3clFbF" id="5Tr1VsJKBLt" role="3cqZAp">
+                      <node concept="2OqwBi" id="5Tr1VsJKCuA" role="3clFbG">
+                        <node concept="2OqwBi" id="5Tr1VsJKBZ2" role="2Oq$k0">
+                          <node concept="30H73N" id="5Tr1VsJKBLs" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="5Tr1VsJKCd1" role="2OqNvi">
+                            <ref role="3Tt5mk" to="yvgz:6po$YwiVDtx" resolve="type" />
+                          </node>
+                        </node>
+                        <node concept="2qgKlT" id="5Tr1VsJKCEV" role="2OqNvi">
+                          <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="356sEF" id="5Tr1VsJK$bG" role="356sEH">
+              <property role="TrG5h" value=" " />
+            </node>
+            <node concept="356sEF" id="5Tr1VsJK$bD" role="356sEH">
+              <property role="TrG5h" value="name" />
+              <node concept="17Uvod" id="5Tr1VsJKEoQ" role="lGtFl">
+                <property role="2qtEX9" value="name" />
+                <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+                <node concept="3zFVjK" id="5Tr1VsJKEoR" role="3zH0cK">
+                  <node concept="3clFbS" id="5Tr1VsJKEoS" role="2VODD2">
+                    <node concept="3cpWs8" id="5Tr1VsJKMJ6" role="3cqZAp">
+                      <node concept="3cpWsn" id="5Tr1VsJKMJ9" role="3cpWs9">
+                        <property role="TrG5h" value="dataBlock" />
+                        <node concept="3Tqbb2" id="5Tr1VsJKMJ4" role="1tU5fm">
+                          <ref role="ehGHo" to="yvgz:29RmJoXeePk" resolve="DataBlock" />
+                        </node>
+                        <node concept="1PxgMI" id="5Tr1VsJKNA4" role="33vP2m">
+                          <property role="1BlNFB" value="true" />
+                          <node concept="chp4Y" id="5Tr1VsJKNCs" role="3oSUPX">
+                            <ref role="cht4Q" to="yvgz:29RmJoXeePk" resolve="DataBlock" />
+                          </node>
+                          <node concept="2OqwBi" id="5Tr1VsJKN4K" role="1m5AlR">
+                            <node concept="30H73N" id="5Tr1VsJKMQt" role="2Oq$k0" />
+                            <node concept="1mfA1w" id="5Tr1VsJKNs4" role="2OqNvi" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="5Tr1VsJKEtv" role="3cqZAp">
+                      <node concept="3cpWs3" id="5Tr1VsJKNSB" role="3clFbG">
+                        <node concept="3cpWs3" id="5Tr1VsJKOfS" role="3uHU7B">
+                          <node concept="2OqwBi" id="5Tr1VsJKOCj" role="3uHU7B">
+                            <node concept="37vLTw" id="5Tr1VsJKOia" role="2Oq$k0">
+                              <ref role="3cqZAo" node="5Tr1VsJKMJ9" resolve="dataBlock" />
+                            </node>
+                            <node concept="3TrcHB" id="5Tr1VsJKOOi" role="2OqNvi">
+                              <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                            </node>
+                          </node>
+                          <node concept="Xl_RD" id="5Tr1VsJKO2L" role="3uHU7w">
+                            <property role="Xl_RC" value="_" />
+                          </node>
+                        </node>
+                        <node concept="2OqwBi" id="5Tr1VsJKEDa" role="3uHU7w">
+                          <node concept="30H73N" id="5Tr1VsJKEtu" role="2Oq$k0" />
+                          <node concept="3TrcHB" id="5Tr1VsJKETn" role="2OqNvi">
+                            <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="356sEF" id="5Tr1VsJK$bK" role="356sEH">
+              <property role="TrG5h" value=";" />
+            </node>
+            <node concept="2EixSi" id="5Tr1VsJKyr5" role="2EinRH" />
+            <node concept="1WS0z7" id="5Tr1VsJK$bR" role="lGtFl">
+              <node concept="3JmXsc" id="5Tr1VsJK$bS" role="3Jn$fo">
+                <node concept="3clFbS" id="5Tr1VsJK$bT" role="2VODD2">
+                  <node concept="3clFbF" id="5Tr1VsJK$eD" role="3cqZAp">
+                    <node concept="2OqwBi" id="5Tr1VsJK$qY" role="3clFbG">
+                      <node concept="30H73N" id="5Tr1VsJK$eC" role="2Oq$k0" />
+                      <node concept="3Tsc0h" id="5Tr1VsJK$yN" role="2OqNvi">
+                        <ref role="3TtcxE" to="yvgz:4iWYoaWUTsk" resolve="data_blocks" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1WS0z7" id="5Tr1VsJKAOw" role="lGtFl">
+              <node concept="3JmXsc" id="5Tr1VsJKAOx" role="3Jn$fo">
+                <node concept="3clFbS" id="5Tr1VsJKAOy" role="2VODD2">
+                  <node concept="3clFbF" id="5Tr1VsJKAQ6" role="3cqZAp">
+                    <node concept="2OqwBi" id="5Tr1VsJKB3O" role="3clFbG">
+                      <node concept="30H73N" id="5Tr1VsJKAQ5" role="2Oq$k0" />
+                      <node concept="3Tsc0h" id="5Tr1VsJKBub" role="2OqNvi">
+                        <ref role="3TtcxE" to="yvgz:6jvQBgXExiw" resolve="ports" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="356sEK" id="5Tr1VsJD_bz" role="383Ya9">
+            <node concept="2EixSi" id="5Tr1VsJD_b_" role="2EinRH" />
+          </node>
+          <node concept="356sEK" id="5Tr1VsJDDFr" role="383Ya9">
+            <node concept="356sEF" id="5Tr1VsJDDFs" role="356sEH">
+              <property role="TrG5h" value="/* schedules */" />
+            </node>
+            <node concept="2EixSi" id="5Tr1VsJDDFt" role="2EinRH" />
+          </node>
+          <node concept="356sEK" id="5Tr1VsJDDFA" role="383Ya9">
+            <node concept="356sEF" id="5Tr1VsJDDFB" role="356sEH">
+              <property role="TrG5h" value="schedules" />
+              <node concept="1WS0z7" id="5Tr1VsJDEGY" role="lGtFl">
+                <node concept="3JmXsc" id="5Tr1VsJDEGZ" role="3Jn$fo">
+                  <node concept="3clFbS" id="5Tr1VsJDEH0" role="2VODD2">
+                    <node concept="3clFbF" id="5Tr1VsJDEJK" role="3cqZAp">
+                      <node concept="2OqwBi" id="5Tr1VsJDEXF" role="3clFbG">
+                        <node concept="30H73N" id="5Tr1VsJDEJJ" role="2Oq$k0" />
+                        <node concept="3Tsc0h" id="5Tr1VsJDF9y" role="2OqNvi">
+                          <ref role="3TtcxE" to="yvgz:4iWYoaWUTsh" resolve="scheduler_blocks" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="1sPUBX" id="5Tr1VsJJBD5" role="lGtFl">
+                <ref role="v9R2y" node="5Tr1VsJJAo1" resolve="switch_SchedulerBlock" />
+              </node>
+            </node>
+            <node concept="2EixSi" id="5Tr1VsJDDFC" role="2EinRH" />
+          </node>
+        </node>
+        <node concept="2EixSi" id="5Tr1VsJD_9R" role="2EinRH" />
+      </node>
+      <node concept="356sEK" id="5Tr1VsJD_2W" role="383Ya9">
+        <node concept="356sEF" id="5Tr1VsJD_2X" role="356sEH">
+          <property role="TrG5h" value="}" />
+        </node>
+        <node concept="2EixSi" id="5Tr1VsJD_2Y" role="2EinRH" />
+      </node>
+    </node>
+    <node concept="n94m4" id="5Tr1VsJDsui" role="lGtFl">
+      <ref role="n9lRv" to="yvgz:7YUYw4xHlaz" resolve="FunctionBlockContainer" />
+    </node>
+    <node concept="17Uvod" id="5Tr1VsJDsuk" role="lGtFl">
+      <property role="2qtEX9" value="name" />
+      <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+      <node concept="3zFVjK" id="5Tr1VsJDsul" role="3zH0cK">
+        <node concept="3clFbS" id="5Tr1VsJDsum" role="2VODD2">
+          <node concept="3clFbF" id="5Tr1VsJDsyY" role="3cqZAp">
+            <node concept="2OqwBi" id="5Tr1VsJDsKC" role="3clFbG">
+              <node concept="30H73N" id="5Tr1VsJDsyX" role="2Oq$k0" />
+              <node concept="3TrcHB" id="5Tr1VsJDsVO" role="2OqNvi">
+                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="13MO4I" id="5Tr1VsJD$im">
+    <property role="TrG5h" value="reduce_EmptyFunctionDef" />
+    <ref role="3gUMe" to="yvgz:29RmJoXeePh" resolve="EmptyFunctionBlock" />
+    <node concept="356WMU" id="5Tr1VsJD$io" role="13RCb5">
+      <node concept="356sEK" id="2FsRs4zCSHt" role="383Ya9">
+        <node concept="2EixSi" id="2FsRs4zCSHv" role="2EinRH" />
+        <node concept="356sEF" id="5Tr1VsJNEUb" role="356sEH">
+          <property role="TrG5h" value="void " />
+        </node>
+        <node concept="356sEF" id="5Tr1VsJNEUg" role="356sEH">
+          <property role="TrG5h" value="functionName" />
+          <node concept="17Uvod" id="5Tr1VsJNEUm" role="lGtFl">
+            <property role="2qtEX9" value="name" />
+            <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+            <node concept="3zFVjK" id="5Tr1VsJNEUn" role="3zH0cK">
+              <node concept="3clFbS" id="5Tr1VsJNEUo" role="2VODD2">
+                <node concept="3clFbF" id="5Tr1VsJNEYZ" role="3cqZAp">
+                  <node concept="2OqwBi" id="5Tr1VsJNFb3" role="3clFbG">
+                    <node concept="30H73N" id="5Tr1VsJNEYY" role="2Oq$k0" />
+                    <node concept="3TrcHB" id="5Tr1VsJNFir" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="356sEF" id="5Tr1VsJLq3_" role="356sEH">
+          <property role="TrG5h" value="function signature" />
+          <node concept="5jKBG" id="5Tr1VsJM0XP" role="lGtFl">
+            <ref role="v9R2y" node="5Tr1VsJLpoy" resolve="include_FunctionDefParams" />
+          </node>
+        </node>
+      </node>
+      <node concept="356sEK" id="2FsRs4zCYi6" role="383Ya9">
+        <node concept="356sEF" id="2FsRs4zCYi7" role="356sEH">
+          <property role="TrG5h" value="{}" />
+        </node>
+        <node concept="2EixSi" id="2FsRs4zCYi8" role="2EinRH" />
+      </node>
+      <node concept="356sEK" id="5Tr1VsJG9SQ" role="383Ya9">
+        <node concept="2EixSi" id="5Tr1VsJG9SS" role="2EinRH" />
+      </node>
+      <node concept="raruj" id="5Tr1VsJD$iu" role="lGtFl" />
+    </node>
+  </node>
+  <node concept="13MO4I" id="5Tr1VsJDHgU">
+    <property role="TrG5h" value="reduce_FixedDataFlowSchedulerBlock" />
+    <ref role="3gUMe" to="yvgz:3EtQu_veq2" resolve="FixedDataFlowSchedulerBlock" />
+    <node concept="356WMU" id="5Tr1VsJDHh3" role="13RCb5">
+      <node concept="356sEK" id="5Tr1VsJDHhb" role="383Ya9">
+        <node concept="356sEF" id="5Tr1VsJDHhc" role="356sEH">
+          <property role="TrG5h" value="// fixed data flow schedule: " />
+        </node>
+        <node concept="356sEF" id="5Tr1VsJDHhh" role="356sEH">
+          <property role="TrG5h" value="name" />
+          <node concept="17Uvod" id="5Tr1VsJDHhk" role="lGtFl">
+            <property role="2qtEX9" value="name" />
+            <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+            <node concept="3zFVjK" id="5Tr1VsJDHhl" role="3zH0cK">
+              <node concept="3clFbS" id="5Tr1VsJDHhm" role="2VODD2">
+                <node concept="3clFbF" id="5Tr1VsJDHlX" role="3cqZAp">
+                  <node concept="2OqwBi" id="5Tr1VsJDHzB" role="3clFbG">
+                    <node concept="30H73N" id="5Tr1VsJDHlW" role="2Oq$k0" />
+                    <node concept="3TrcHB" id="5Tr1VsJDHRr" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2EixSi" id="5Tr1VsJDHhd" role="2EinRH" />
+      </node>
+      <node concept="356sEK" id="5Tr1VsJDHYC" role="383Ya9">
+        <node concept="356sEF" id="5Tr1VsJDHYD" role="356sEH">
+          <property role="TrG5h" value="functionCall()" />
+          <node concept="1sPUBX" id="5Tr1VsJKrD4" role="lGtFl">
+            <ref role="v9R2y" node="5Tr1VsJKqPj" resolve="switch_FunctionCall" />
+          </node>
+        </node>
+        <node concept="356sEF" id="5Tr1VsJDHZu" role="356sEH">
+          <property role="TrG5h" value=";" />
+        </node>
+        <node concept="2EixSi" id="5Tr1VsJDHYE" role="2EinRH" />
+        <node concept="1WS0z7" id="5Tr1VsJDHZz" role="lGtFl">
+          <node concept="3JmXsc" id="5Tr1VsJDHZ$" role="3Jn$fo">
+            <node concept="3clFbS" id="5Tr1VsJDHZ_" role="2VODD2">
+              <node concept="3cpWs8" id="5Tr1VsJDK5j" role="3cqZAp">
+                <node concept="3cpWsn" id="5Tr1VsJDK5m" role="3cpWs9">
+                  <property role="TrG5h" value="parent" />
+                  <node concept="3Tqbb2" id="5Tr1VsJDK5h" role="1tU5fm">
+                    <ref role="ehGHo" to="yvgz:7YUYw4xHlaz" resolve="FunctionBlockContainer" />
+                  </node>
+                  <node concept="1PxgMI" id="5Tr1VsJDKPh" role="33vP2m">
+                    <property role="1BlNFB" value="true" />
+                    <node concept="chp4Y" id="5Tr1VsJDKWl" role="3oSUPX">
+                      <ref role="cht4Q" to="yvgz:7YUYw4xHlaz" resolve="FunctionBlockContainer" />
+                    </node>
+                    <node concept="2OqwBi" id="5Tr1VsJDKuo" role="1m5AlR">
+                      <node concept="30H73N" id="5Tr1VsJDKfe" role="2Oq$k0" />
+                      <node concept="1mfA1w" id="5Tr1VsJDKEq" role="2OqNvi" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs8" id="5Tr1VsJDLlo" role="3cqZAp">
+                <node concept="3cpWsn" id="5Tr1VsJDLlr" role="3cpWs9">
+                  <property role="TrG5h" value="functions" />
+                  <node concept="2I9FWS" id="5Tr1VsJDLlm" role="1tU5fm">
+                    <ref role="2I9WkF" to="yvgz:3eP8Zudp5G4" resolve="FunctionBlock" />
+                  </node>
+                  <node concept="2ShNRf" id="5Tr1VsJDPKF" role="33vP2m">
+                    <node concept="2T8Vx0" id="5Tr1VsJDPUR" role="2ShVmc">
+                      <node concept="2I9FWS" id="5Tr1VsJDPUT" role="2T96Bj">
+                        <ref role="2I9WkF" to="yvgz:3eP8Zudp5G4" resolve="FunctionBlock" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="5Tr1VsJDI2l" role="3cqZAp">
+                <node concept="2OqwBi" id="5Tr1VsJDNix" role="3clFbG">
+                  <node concept="2OqwBi" id="5Tr1VsJDIg0" role="2Oq$k0">
+                    <node concept="30H73N" id="5Tr1VsJDI2k" role="2Oq$k0" />
+                    <node concept="3Tsc0h" id="5Tr1VsJDIr$" role="2OqNvi">
+                      <ref role="3TtcxE" to="yvgz:3EtQu_veq3" resolve="schedule" />
+                    </node>
+                  </node>
+                  <node concept="2es0OD" id="5Tr1VsJDP0z" role="2OqNvi">
+                    <node concept="1bVj0M" id="5Tr1VsJDP0_" role="23t8la">
+                      <node concept="3clFbS" id="5Tr1VsJDP0A" role="1bW5cS">
+                        <node concept="3cpWs8" id="5Tr1VsJDTLj" role="3cqZAp">
+                          <node concept="3cpWsn" id="5Tr1VsJDTLk" role="3cpWs9">
+                            <property role="TrG5h" value="connectedPorts" />
+                            <node concept="2OqwBi" id="5Tr1VsJDQx6" role="33vP2m">
+                              <node concept="37vLTw" id="5Tr1VsJDQfJ" role="2Oq$k0">
+                                <ref role="3cqZAo" node="5Tr1VsJDK5m" resolve="parent" />
+                              </node>
+                              <node concept="2qgKlT" id="5Tr1VsJDQP4" role="2OqNvi">
+                                <ref role="37wK5l" to="ixp9:2RC7aVK84L5" resolve="findConnectedTriggerPorts" />
+                                <node concept="2OqwBi" id="5Tr1VsJDRiF" role="37wK5m">
+                                  <node concept="37vLTw" id="5Tr1VsJDQYr" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="5Tr1VsJDP0B" resolve="trigPortRef" />
+                                  </node>
+                                  <node concept="3TrEf2" id="5Tr1VsJDRtG" role="2OqNvi">
+                                    <ref role="3Tt5mk" to="yvgz:3EtQu_woIa" resolve="trigger_port" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="2I9FWS" id="5Tr1VsJDWsB" role="1tU5fm">
+                              <ref role="2I9WkF" to="yvgz:6jvQBgXEYiM" resolve="TriggerPort" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbJ" id="5Tr1VsJHktU" role="3cqZAp">
+                          <node concept="3clFbS" id="5Tr1VsJHktW" role="3clFbx">
+                            <node concept="3cpWs8" id="5Tr1VsJHt5S" role="3cqZAp">
+                              <node concept="3cpWsn" id="5Tr1VsJHt5T" role="3cpWs9">
+                                <property role="TrG5h" value="errMsg" />
+                                <node concept="17QB3L" id="5Tr1VsJHt5U" role="1tU5fm" />
+                                <node concept="3cpWs3" id="5Tr1VsJHt5V" role="33vP2m">
+                                  <node concept="Xl_RD" id="5Tr1VsJHt5W" role="3uHU7w">
+                                    <property role="Xl_RC" value="' is not connected to exactly 1 other port" />
+                                  </node>
+                                  <node concept="3cpWs3" id="5Tr1VsJHt5X" role="3uHU7B">
+                                    <node concept="Xl_RD" id="5Tr1VsJHt5Y" role="3uHU7B">
+                                      <property role="Xl_RC" value="port '" />
+                                    </node>
+                                    <node concept="2OqwBi" id="5Tr1VsJH_C6" role="3uHU7w">
+                                      <node concept="2OqwBi" id="5Tr1VsJH$In" role="2Oq$k0">
+                                        <node concept="37vLTw" id="5Tr1VsJH$lF" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="5Tr1VsJDP0B" resolve="trigPortRef" />
+                                        </node>
+                                        <node concept="3TrEf2" id="5Tr1VsJH_7t" role="2OqNvi">
+                                          <ref role="3Tt5mk" to="yvgz:3EtQu_woIa" resolve="trigger_port" />
+                                        </node>
+                                      </node>
+                                      <node concept="3TrcHB" id="5Tr1VsJHA3r" role="2OqNvi">
+                                        <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="RRSsy" id="5Tr1VsJHt62" role="3cqZAp">
+                              <property role="RRSoG" value="gZ5fh_4/error" />
+                              <node concept="37vLTw" id="5Tr1VsJHt63" role="RRSoy">
+                                <ref role="3cqZAo" node="5Tr1VsJHt5T" resolve="errMsg" />
+                              </node>
+                              <node concept="2ShNRf" id="5Tr1VsJHt64" role="RRSow">
+                                <node concept="1pGfFk" id="5Tr1VsJHt65" role="2ShVmc">
+                                  <ref role="37wK5l" to="wyt6:~RuntimeException.&lt;init&gt;(java.lang.String)" resolve="RuntimeException" />
+                                  <node concept="37vLTw" id="5Tr1VsJHt66" role="37wK5m">
+                                    <ref role="3cqZAo" node="5Tr1VsJHt5T" resolve="errMsg" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3y3z36" id="5Tr1VsJHs9k" role="3clFbw">
+                            <node concept="3cmrfG" id="5Tr1VsJHsPq" role="3uHU7w">
+                              <property role="3cmrfH" value="1" />
+                            </node>
+                            <node concept="2OqwBi" id="5Tr1VsJHmQf" role="3uHU7B">
+                              <node concept="37vLTw" id="5Tr1VsJHkJt" role="2Oq$k0">
+                                <ref role="3cqZAo" node="5Tr1VsJDTLk" resolve="connectedPorts" />
+                              </node>
+                              <node concept="34oBXx" id="5Tr1VsJHqzC" role="2OqNvi" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3cpWs8" id="5Tr1VsJHEkm" role="3cqZAp">
+                          <node concept="3cpWsn" id="5Tr1VsJHEkp" role="3cpWs9">
+                            <property role="TrG5h" value="connectedParent" />
+                            <node concept="3Tqbb2" id="5Tr1VsJHEkk" role="1tU5fm">
+                              <ref role="ehGHo" to="yvgz:3eP8Zudp5G4" resolve="FunctionBlock" />
+                            </node>
+                            <node concept="1PxgMI" id="5Tr1VsJHMWK" role="33vP2m">
+                              <property role="1BlNFB" value="true" />
+                              <node concept="chp4Y" id="5Tr1VsJHNfL" role="3oSUPX">
+                                <ref role="cht4Q" to="yvgz:3eP8Zudp5G4" resolve="FunctionBlock" />
+                              </node>
+                              <node concept="2OqwBi" id="5Tr1VsJHLbe" role="1m5AlR">
+                                <node concept="2OqwBi" id="5Tr1VsJHI5i" role="2Oq$k0">
+                                  <node concept="37vLTw" id="5Tr1VsJHFW4" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="5Tr1VsJDTLk" resolve="connectedPorts" />
+                                  </node>
+                                  <node concept="1uHKPH" id="5Tr1VsJHKaX" role="2OqNvi" />
+                                </node>
+                                <node concept="1mfA1w" id="5Tr1VsJHMwH" role="2OqNvi" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbJ" id="5Tr1VsJHNzz" role="3cqZAp">
+                          <node concept="3clFbS" id="5Tr1VsJHNz_" role="3clFbx">
+                            <node concept="3cpWs8" id="5Tr1VsJHPUh" role="3cqZAp">
+                              <node concept="3cpWsn" id="5Tr1VsJHPUi" role="3cpWs9">
+                                <property role="TrG5h" value="errMsg" />
+                                <node concept="17QB3L" id="5Tr1VsJHPUj" role="1tU5fm" />
+                                <node concept="3cpWs3" id="5Tr1VsJHPUk" role="33vP2m">
+                                  <node concept="Xl_RD" id="5Tr1VsJHPUl" role="3uHU7w">
+                                    <property role="Xl_RC" value="' is null" />
+                                  </node>
+                                  <node concept="3cpWs3" id="5Tr1VsJHPUm" role="3uHU7B">
+                                    <node concept="Xl_RD" id="5Tr1VsJHPUn" role="3uHU7B">
+                                      <property role="Xl_RC" value="parent of port'" />
+                                    </node>
+                                    <node concept="2OqwBi" id="5Tr1VsJHZlf" role="3uHU7w">
+                                      <node concept="2OqwBi" id="5Tr1VsJHVOu" role="2Oq$k0">
+                                        <node concept="37vLTw" id="5Tr1VsJHTWJ" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="5Tr1VsJDTLk" resolve="connectedPorts" />
+                                        </node>
+                                        <node concept="1uHKPH" id="5Tr1VsJHYx4" role="2OqNvi" />
+                                      </node>
+                                      <node concept="3TrcHB" id="5Tr1VsJHZOU" role="2OqNvi">
+                                        <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="RRSsy" id="5Tr1VsJHPUr" role="3cqZAp">
+                              <property role="RRSoG" value="gZ5fh_4/error" />
+                              <node concept="37vLTw" id="5Tr1VsJHPUs" role="RRSoy">
+                                <ref role="3cqZAo" node="5Tr1VsJHPUi" resolve="errMsg" />
+                              </node>
+                              <node concept="2ShNRf" id="5Tr1VsJHPUt" role="RRSow">
+                                <node concept="1pGfFk" id="5Tr1VsJHPUu" role="2ShVmc">
+                                  <ref role="37wK5l" to="wyt6:~RuntimeException.&lt;init&gt;(java.lang.String)" resolve="RuntimeException" />
+                                  <node concept="37vLTw" id="5Tr1VsJHPUv" role="37wK5m">
+                                    <ref role="3cqZAo" node="5Tr1VsJHPUi" resolve="errMsg" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="2OqwBi" id="5Tr1VsJHP6s" role="3clFbw">
+                            <node concept="37vLTw" id="5Tr1VsJHNRi" role="2Oq$k0">
+                              <ref role="3cqZAo" node="5Tr1VsJHEkp" resolve="connectedParent" />
+                            </node>
+                            <node concept="3w_OXm" id="5Tr1VsJHPz6" role="2OqNvi" />
+                          </node>
+                        </node>
+                        <node concept="3clFbF" id="5Tr1VsJEbN4" role="3cqZAp">
+                          <node concept="2OqwBi" id="5Tr1VsJEdMm" role="3clFbG">
+                            <node concept="37vLTw" id="5Tr1VsJEbN2" role="2Oq$k0">
+                              <ref role="3cqZAo" node="5Tr1VsJDLlr" resolve="functions" />
+                            </node>
+                            <node concept="TSZUe" id="5Tr1VsJEhcr" role="2OqNvi">
+                              <node concept="37vLTw" id="5Tr1VsJI2cP" role="25WWJ7">
+                                <ref role="3cqZAo" node="5Tr1VsJHEkp" resolve="connectedParent" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="Rh6nW" id="5Tr1VsJDP0B" role="1bW2Oz">
+                        <property role="TrG5h" value="trigPortRef" />
+                        <node concept="2jxLKc" id="5Tr1VsJDP0C" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="5Tr1VsJDPqI" role="3cqZAp">
+                <node concept="37vLTw" id="5Tr1VsJDPqG" role="3clFbG">
+                  <ref role="3cqZAo" node="5Tr1VsJDLlr" resolve="functions" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="raruj" id="5Tr1VsJDHh9" role="lGtFl" />
+      <node concept="356sEK" id="5Tr1VsJDSGT" role="383Ya9">
+        <node concept="2EixSi" id="5Tr1VsJDSGV" role="2EinRH" />
+      </node>
+    </node>
+  </node>
+  <node concept="13MO4I" id="5Tr1VsJEoGm">
+    <property role="TrG5h" value="reduce_EmptyFunctionCall" />
+    <ref role="3gUMe" to="yvgz:29RmJoXeePh" resolve="EmptyFunctionBlock" />
+    <node concept="356WMU" id="5Tr1VsJEoGo" role="13RCb5">
+      <node concept="356sEK" id="Ho3faVHPYv" role="383Ya9">
+        <node concept="2EixSi" id="Ho3faVHPYx" role="2EinRH" />
+        <node concept="356sEF" id="5Tr1VsJM9TM" role="356sEH">
+          <property role="TrG5h" value="functioName" />
+          <node concept="17Uvod" id="5Tr1VsJM9X4" role="lGtFl">
+            <property role="2qtEX9" value="name" />
+            <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+            <node concept="3zFVjK" id="5Tr1VsJM9X5" role="3zH0cK">
+              <node concept="3clFbS" id="5Tr1VsJM9X6" role="2VODD2">
+                <node concept="3clFbF" id="5Tr1VsJMa1H" role="3cqZAp">
+                  <node concept="2OqwBi" id="5Tr1VsJMadL" role="3clFbG">
+                    <node concept="30H73N" id="5Tr1VsJMa1G" role="2Oq$k0" />
+                    <node concept="3TrcHB" id="5Tr1VsJMal9" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="356sEF" id="5Tr1VsJMau8" role="356sEH">
+          <property role="TrG5h" value="(" />
+        </node>
+        <node concept="356sEF" id="Ho3faVHPY_" role="356sEH">
+          <property role="TrG5h" value="function_call()" />
+          <node concept="17Uvod" id="Ho3faVHPYC" role="lGtFl">
+            <property role="2qtEX9" value="name" />
+            <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+            <node concept="3zFVjK" id="Ho3faVHPYD" role="3zH0cK">
+              <node concept="3clFbS" id="Ho3faVHPYE" role="2VODD2">
+                <node concept="3cpWs8" id="5Tr1VsJMGfe" role="3cqZAp">
+                  <node concept="3cpWsn" id="5Tr1VsJMGfh" role="3cpWs9">
+                    <property role="TrG5h" value="parent" />
+                    <node concept="3Tqbb2" id="5Tr1VsJMGfc" role="1tU5fm">
+                      <ref role="ehGHo" to="yvgz:7YUYw4xHlaz" resolve="FunctionBlockContainer" />
+                    </node>
+                    <node concept="1PxgMI" id="5Tr1VsJMHrX" role="33vP2m">
+                      <property role="1BlNFB" value="true" />
+                      <node concept="chp4Y" id="5Tr1VsJMHDO" role="3oSUPX">
+                        <ref role="cht4Q" to="yvgz:7YUYw4xHlaz" resolve="FunctionBlockContainer" />
+                      </node>
+                      <node concept="2OqwBi" id="5Tr1VsJMH1P" role="1m5AlR">
+                        <node concept="30H73N" id="5Tr1VsJMGFc" role="2Oq$k0" />
+                        <node concept="1mfA1w" id="5Tr1VsJMHdv" role="2OqNvi" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="5Tr1VsJMI0z" role="3cqZAp">
+                  <node concept="3clFbS" id="5Tr1VsJMI0_" role="3clFbx">
+                    <node concept="3cpWs8" id="5Tr1VsJMWk4" role="3cqZAp">
+                      <node concept="3cpWsn" id="5Tr1VsJMWk7" role="3cpWs9">
+                        <property role="TrG5h" value="errString" />
+                        <node concept="17QB3L" id="5Tr1VsJMWk2" role="1tU5fm" />
+                        <node concept="3cpWs3" id="5Tr1VsJMNWL" role="33vP2m">
+                          <node concept="2OqwBi" id="5Tr1VsJMP9I" role="3uHU7w">
+                            <node concept="2OqwBi" id="5Tr1VsJMOud" role="2Oq$k0">
+                              <node concept="30H73N" id="5Tr1VsJMO39" role="2Oq$k0" />
+                              <node concept="1mfA1w" id="5Tr1VsJMOX0" role="2OqNvi" />
+                            </node>
+                            <node concept="2qgKlT" id="5Tr1VsJMPlq" role="2OqNvi">
+                              <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                            </node>
+                          </node>
+                          <node concept="3cpWs3" id="5Tr1VsJMMe1" role="3uHU7B">
+                            <node concept="3cpWs3" id="5Tr1VsJMKF3" role="3uHU7B">
+                              <node concept="Xl_RD" id="5Tr1VsJMIMZ" role="3uHU7B">
+                                <property role="Xl_RC" value="can't cast parent of function '" />
+                              </node>
+                              <node concept="2OqwBi" id="5Tr1VsJMLbg" role="3uHU7w">
+                                <node concept="30H73N" id="5Tr1VsJMKK_" role="2Oq$k0" />
+                                <node concept="3TrcHB" id="5Tr1VsJMLnA" role="2OqNvi">
+                                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="Xl_RD" id="5Tr1VsJMMkd" role="3uHU7w">
+                              <property role="Xl_RC" value="' as FunctionBlockContainer, parent: " />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="RRSsy" id="5Tr1VsJMIMX" role="3cqZAp">
+                      <property role="RRSoG" value="gZ5fh_4/error" />
+                      <node concept="37vLTw" id="5Tr1VsJMY7M" role="RRSoy">
+                        <ref role="3cqZAo" node="5Tr1VsJMWk7" resolve="errString" />
+                      </node>
+                      <node concept="2ShNRf" id="5Tr1VsJMYf0" role="RRSow">
+                        <node concept="1pGfFk" id="5Tr1VsJMYsG" role="2ShVmc">
+                          <ref role="37wK5l" to="wyt6:~RuntimeException.&lt;init&gt;(java.lang.String)" resolve="RuntimeException" />
+                          <node concept="37vLTw" id="5Tr1VsJMZ2o" role="37wK5m">
+                            <ref role="3cqZAo" node="5Tr1VsJMWk7" resolve="errString" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="5Tr1VsJMIpp" role="3clFbw">
+                    <node concept="37vLTw" id="5Tr1VsJMI6G" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5Tr1VsJMGfh" resolve="parent" />
+                    </node>
+                    <node concept="3w_OXm" id="5Tr1VsJMIDq" role="2OqNvi" />
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="5Tr1VsJMh0F" role="3cqZAp">
+                  <node concept="3cpWsn" id="5Tr1VsJMh0I" role="3cpWs9">
+                    <property role="TrG5h" value="argString" />
+                    <node concept="17QB3L" id="5Tr1VsJMh0D" role="1tU5fm" />
+                    <node concept="Xl_RD" id="5Tr1VsJMhlC" role="33vP2m">
+                      <property role="Xl_RC" value="" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="1Dw8fO" id="5Tr1VsJMhV$" role="3cqZAp">
+                  <node concept="3clFbS" id="5Tr1VsJMhVA" role="2LFqv$">
+                    <node concept="3clFbJ" id="5Tr1VsJMqIP" role="3cqZAp">
+                      <node concept="3clFbS" id="5Tr1VsJMqIR" role="3clFbx">
+                        <node concept="3clFbF" id="5Tr1VsJMr93" role="3cqZAp">
+                          <node concept="d57v9" id="5Tr1VsJMrBr" role="3clFbG">
+                            <node concept="Xl_RD" id="5Tr1VsJMrFG" role="37vLTx">
+                              <property role="Xl_RC" value=", " />
+                            </node>
+                            <node concept="37vLTw" id="5Tr1VsJMr91" role="37vLTJ">
+                              <ref role="3cqZAo" node="5Tr1VsJMh0I" resolve="argString" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3eOSWO" id="5Tr1VsJMr0h" role="3clFbw">
+                        <node concept="3cmrfG" id="5Tr1VsJMr4C" role="3uHU7w">
+                          <property role="3cmrfH" value="0" />
+                        </node>
+                        <node concept="37vLTw" id="5Tr1VsJMqNa" role="3uHU7B">
+                          <ref role="3cqZAo" node="5Tr1VsJMhVB" resolve="i" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3cpWs8" id="5Tr1VsJNi86" role="3cqZAp">
+                      <node concept="3cpWsn" id="5Tr1VsJNi89" role="3cpWs9">
+                        <property role="TrG5h" value="currPort" />
+                        <node concept="3Tqbb2" id="5Tr1VsJNi84" role="1tU5fm">
+                          <ref role="ehGHo" to="yvgz:6po$YwiVCCi" resolve="DataPort" />
+                        </node>
+                        <node concept="1y4W85" id="5Tr1VsJNmGL" role="33vP2m">
+                          <node concept="37vLTw" id="5Tr1VsJNnGn" role="1y58nS">
+                            <ref role="3cqZAo" node="5Tr1VsJMhVB" resolve="i" />
+                          </node>
+                          <node concept="2OqwBi" id="5Tr1VsJNk9N" role="1y566C">
+                            <node concept="30H73N" id="5Tr1VsJNjGv" role="2Oq$k0" />
+                            <node concept="3Tsc0h" id="5Tr1VsJNkqe" role="2OqNvi">
+                              <ref role="3TtcxE" to="yvgz:3eP8Zudp5G8" resolve="data_ports" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3cpWs8" id="5Tr1VsJMP_w" role="3cqZAp">
+                      <node concept="3cpWsn" id="5Tr1VsJMP_z" role="3cpWs9">
+                        <property role="TrG5h" value="connectedPorts" />
+                        <node concept="2I9FWS" id="5Tr1VsJMQpQ" role="1tU5fm">
+                          <ref role="2I9WkF" to="yvgz:6po$YwiVCCi" resolve="DataPort" />
+                        </node>
+                        <node concept="2OqwBi" id="5Tr1VsJMRow" role="33vP2m">
+                          <node concept="37vLTw" id="5Tr1VsJMRdY" role="2Oq$k0">
+                            <ref role="3cqZAo" node="5Tr1VsJMGfh" resolve="parent" />
+                          </node>
+                          <node concept="2qgKlT" id="5Tr1VsJMRvX" role="2OqNvi">
+                            <ref role="37wK5l" to="ixp9:1Fy8yZq9o69" resolve="findConnectedDataPorts" />
+                            <node concept="37vLTw" id="5Tr1VsJNotc" role="37wK5m">
+                              <ref role="3cqZAo" node="5Tr1VsJNi89" resolve="currPort" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbJ" id="5Tr1VsJMwV2" role="3cqZAp">
+                      <node concept="3clFbS" id="5Tr1VsJMwV4" role="3clFbx">
+                        <node concept="3cpWs8" id="5Tr1VsJN8Kr" role="3cqZAp">
+                          <node concept="3cpWsn" id="5Tr1VsJN8Ku" role="3cpWs9">
+                            <property role="TrG5h" value="errString" />
+                            <node concept="17QB3L" id="5Tr1VsJN8Kp" role="1tU5fm" />
+                            <node concept="3cpWs3" id="5Tr1VsJNfaA" role="33vP2m">
+                              <node concept="3cpWs3" id="5Tr1VsJNdQz" role="3uHU7B">
+                                <node concept="3cpWs3" id="5Tr1VsJNgHy" role="3uHU7B">
+                                  <node concept="3cpWs3" id="5Tr1VsJNq08" role="3uHU7B">
+                                    <node concept="Xl_RD" id="5Tr1VsJNhG2" role="3uHU7B">
+                                      <property role="Xl_RC" value="port '" />
+                                    </node>
+                                    <node concept="2OqwBi" id="5Tr1VsJNqpg" role="3uHU7w">
+                                      <node concept="37vLTw" id="5Tr1VsJNq9h" role="2Oq$k0">
+                                        <ref role="3cqZAo" node="5Tr1VsJNi89" resolve="currPort" />
+                                      </node>
+                                      <node concept="3TrcHB" id="5Tr1VsJNqFN" role="2OqNvi">
+                                        <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="Xl_RD" id="5Tr1VsJNa6l" role="3uHU7w">
+                                    <property role="Xl_RC" value="' of function '" />
+                                  </node>
+                                </node>
+                                <node concept="2OqwBi" id="5Tr1VsJNes3" role="3uHU7w">
+                                  <node concept="30H73N" id="5Tr1VsJNdZg" role="2Oq$k0" />
+                                  <node concept="3TrcHB" id="5Tr1VsJNeCE" role="2OqNvi">
+                                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="Xl_RD" id="5Tr1VsJNgrw" role="3uHU7w">
+                                <property role="Xl_RC" value="' is not connected to exactly 1 other DataPort" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="RRSsy" id="5Tr1VsJN7Ex" role="3cqZAp">
+                          <property role="RRSoG" value="gZ5fh_4/error" />
+                          <node concept="37vLTw" id="5Tr1VsJNc3q" role="RRSoy">
+                            <ref role="3cqZAo" node="5Tr1VsJN8Ku" resolve="errString" />
+                          </node>
+                          <node concept="2ShNRf" id="5Tr1VsJNcbz" role="RRSow">
+                            <node concept="1pGfFk" id="5Tr1VsJNcqj" role="2ShVmc">
+                              <ref role="37wK5l" to="wyt6:~RuntimeException.&lt;init&gt;(java.lang.String)" resolve="RuntimeException" />
+                              <node concept="37vLTw" id="5Tr1VsJNdlZ" role="37wK5m">
+                                <ref role="3cqZAo" node="5Tr1VsJN8Ku" resolve="errString" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3y3z36" id="5Tr1VsJN6$L" role="3clFbw">
+                        <node concept="3cmrfG" id="5Tr1VsJN7yw" role="3uHU7w">
+                          <property role="3cmrfH" value="1" />
+                        </node>
+                        <node concept="2OqwBi" id="5Tr1VsJN3aD" role="3uHU7B">
+                          <node concept="37vLTw" id="5Tr1VsJN0Hu" role="2Oq$k0">
+                            <ref role="3cqZAo" node="5Tr1VsJMP_z" resolve="connectedPorts" />
+                          </node>
+                          <node concept="34oBXx" id="5Tr1VsJN5gO" role="2OqNvi" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbJ" id="5Tr1VsJNxpR" role="3cqZAp">
+                      <node concept="3clFbS" id="5Tr1VsJNxpT" role="3clFbx">
+                        <node concept="3clFbH" id="5Tr1VsJNxpS" role="3cqZAp" />
+                      </node>
+                      <node concept="2OqwBi" id="5Tr1VsJNBTe" role="3clFbw">
+                        <node concept="2OqwBi" id="5Tr1VsJNBg8" role="2Oq$k0">
+                          <node concept="2OqwBi" id="5Tr1VsJNzQQ" role="2Oq$k0">
+                            <node concept="37vLTw" id="5Tr1VsJNx$p" role="2Oq$k0">
+                              <ref role="3cqZAo" node="5Tr1VsJMP_z" resolve="connectedPorts" />
+                            </node>
+                            <node concept="1uHKPH" id="5Tr1VsJN_K1" role="2OqNvi" />
+                          </node>
+                          <node concept="3TrcHB" id="5Tr1VsJNB_o" role="2OqNvi">
+                            <ref role="3TsBF5" to="yvgz:6po$YwiVCCu" resolve="direction" />
+                          </node>
+                        </node>
+                        <node concept="21noJN" id="5Tr1VsJNCaV" role="2OqNvi">
+                          <node concept="21nZrQ" id="5Tr1VsJNJGk" role="21noJM">
+                            <ref role="21nZrZ" to="yvgz:6po$YwiVCCn" resolve="Out" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="5Tr1VsJNL1d" role="3cqZAp">
+                      <node concept="d57v9" id="5Tr1VsJNMw0" role="3clFbG">
+                        <node concept="2OqwBi" id="5Tr1VsJNSo_" role="37vLTx">
+                          <node concept="2OqwBi" id="5Tr1VsJNOU7" role="2Oq$k0">
+                            <node concept="37vLTw" id="5Tr1VsJNMGJ" role="2Oq$k0">
+                              <ref role="3cqZAo" node="5Tr1VsJMP_z" resolve="connectedPorts" />
+                            </node>
+                            <node concept="1uHKPH" id="5Tr1VsJNQLU" role="2OqNvi" />
+                          </node>
+                          <node concept="3TrcHB" id="5Tr1VsJNSSY" role="2OqNvi">
+                            <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                          </node>
+                        </node>
+                        <node concept="37vLTw" id="5Tr1VsJNL1b" role="37vLTJ">
+                          <ref role="3cqZAo" node="5Tr1VsJMh0I" resolve="argString" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cpWsn" id="5Tr1VsJMhVB" role="1Duv9x">
+                    <property role="TrG5h" value="i" />
+                    <node concept="10Oyi0" id="5Tr1VsJMi1T" role="1tU5fm" />
+                    <node concept="3cmrfG" id="5Tr1VsJMiaN" role="33vP2m">
+                      <property role="3cmrfH" value="0" />
+                    </node>
+                  </node>
+                  <node concept="3eOVzh" id="5Tr1VsJMjif" role="1Dwp0S">
+                    <node concept="37vLTw" id="5Tr1VsJMimo" role="3uHU7B">
+                      <ref role="3cqZAo" node="5Tr1VsJMhVB" resolve="i" />
+                    </node>
+                    <node concept="2OqwBi" id="5Tr1VsJMnq1" role="3uHU7w">
+                      <node concept="2OqwBi" id="5Tr1VsJMksH" role="2Oq$k0">
+                        <node concept="30H73N" id="5Tr1VsJMjWf" role="2Oq$k0" />
+                        <node concept="3Tsc0h" id="5Tr1VsJMkJx" role="2OqNvi">
+                          <ref role="3TtcxE" to="yvgz:3eP8Zudp5G8" resolve="data_ports" />
+                        </node>
+                      </node>
+                      <node concept="34oBXx" id="5Tr1VsJMpsD" role="2OqNvi" />
+                    </node>
+                  </node>
+                  <node concept="3uNrnE" id="5Tr1VsJMqxV" role="1Dwrff">
+                    <node concept="37vLTw" id="5Tr1VsJMqxX" role="2$L3a6">
+                      <ref role="3cqZAo" node="5Tr1VsJMhVB" resolve="i" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="Ho3faVHQ3h" role="3cqZAp">
+                  <node concept="37vLTw" id="5Tr1VsJMhFu" role="3clFbG">
+                    <ref role="3cqZAo" node="5Tr1VsJMh0I" resolve="argString" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="356sEF" id="5Tr1VsJMgP8" role="356sEH">
+          <property role="TrG5h" value=")" />
+        </node>
+      </node>
+      <node concept="raruj" id="5Tr1VsJEoGu" role="lGtFl" />
+    </node>
+  </node>
+  <node concept="jVnub" id="5Tr1VsJJAo1">
+    <property role="TrG5h" value="switch_SchedulerBlock" />
+    <node concept="3aamgX" id="5Tr1VsJJAxB" role="3aUrZf">
+      <property role="36QftV" value="true" />
+      <ref role="30HIoZ" to="yvgz:3EtQu_tAJA" resolve="EmptySchedulerBlock" />
+      <node concept="gft3U" id="5Tr1VsJJAxF" role="1lVwrX">
+        <node concept="356WMU" id="5Tr1VsJJAxL" role="gfFT$">
+          <node concept="356sEK" id="5Tr1VsJJAxN" role="383Ya9">
+            <node concept="356sEF" id="5Tr1VsJJAxO" role="356sEH">
+              <property role="TrG5h" value="// empty schedule: " />
+            </node>
+            <node concept="356sEF" id="5Tr1VsJJAxT" role="356sEH">
+              <property role="TrG5h" value="name" />
+              <node concept="17Uvod" id="5Tr1VsJJAxY" role="lGtFl">
+                <property role="2qtEX9" value="name" />
+                <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+                <node concept="3zFVjK" id="5Tr1VsJJAxZ" role="3zH0cK">
+                  <node concept="3clFbS" id="5Tr1VsJJAy0" role="2VODD2">
+                    <node concept="3clFbF" id="5Tr1VsJJAAB" role="3cqZAp">
+                      <node concept="2OqwBi" id="5Tr1VsJJANB" role="3clFbG">
+                        <node concept="30H73N" id="5Tr1VsJJAAA" role="2Oq$k0" />
+                        <node concept="3TrcHB" id="5Tr1VsJJAXT" role="2OqNvi">
+                          <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2EixSi" id="5Tr1VsJJAxP" role="2EinRH" />
+          </node>
+          <node concept="356sEK" id="5Tr1VsJJBbY" role="383Ya9">
+            <node concept="2EixSi" id="5Tr1VsJJBc0" role="2EinRH" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3aamgX" id="5Tr1VsJJBj3" role="3aUrZf">
+      <property role="36QftV" value="true" />
+      <ref role="30HIoZ" to="yvgz:3EtQu_veq2" resolve="FixedDataFlowSchedulerBlock" />
+      <node concept="j$656" id="5Tr1VsJJBjt" role="1lVwrX">
+        <ref role="v9R2y" node="5Tr1VsJDHgU" resolve="reduce_FixedDataFlowSchedulerBlock" />
+      </node>
+    </node>
+  </node>
+  <node concept="jVnub" id="5Tr1VsJKqPb">
+    <property role="TrG5h" value="switch_FunctionDef" />
+    <node concept="3aamgX" id="5Tr1VsJKqPc" role="3aUrZf">
+      <property role="36QftV" value="true" />
+      <ref role="30HIoZ" to="yvgz:29RmJoXeePh" resolve="EmptyFunctionBlock" />
+      <node concept="j$656" id="5Tr1VsJKqPg" role="1lVwrX">
+        <ref role="v9R2y" node="5Tr1VsJD$im" resolve="reduce_EmptyFunctionDef" />
+      </node>
+    </node>
+  </node>
+  <node concept="jVnub" id="5Tr1VsJKqPj">
+    <property role="TrG5h" value="switch_FunctionCall" />
+    <node concept="3aamgX" id="5Tr1VsJKqPk" role="3aUrZf">
+      <property role="36QftV" value="true" />
+      <ref role="30HIoZ" to="yvgz:29RmJoXeePh" resolve="EmptyFunctionBlock" />
+      <node concept="j$656" id="5Tr1VsJKqPo" role="1lVwrX">
+        <ref role="v9R2y" node="5Tr1VsJEoGm" resolve="reduce_EmptyFunctionCall" />
+      </node>
+    </node>
+  </node>
+  <node concept="13MO4I" id="5Tr1VsJLpoy">
+    <property role="TrG5h" value="include_FunctionDefParams" />
+    <ref role="3gUMe" to="yvgz:3eP8Zudp5G4" resolve="FunctionBlock" />
+    <node concept="356WMU" id="5Tr1VsJLppm" role="13RCb5">
+      <node concept="356sEK" id="5Tr1VsJLqqF" role="383Ya9">
+        <node concept="356sEF" id="5Tr1VsJLEtF" role="356sEH">
+          <property role="TrG5h" value="(" />
+        </node>
+        <node concept="356sEF" id="5Tr1VsJLqqL" role="356sEH">
+          <property role="TrG5h" value="data ports" />
+          <node concept="1WS0z7" id="5Tr1VsJLqqM" role="lGtFl">
+            <property role="1qytDF" value="dataPortCount" />
+            <node concept="3JmXsc" id="5Tr1VsJLqqN" role="3Jn$fo">
+              <node concept="3clFbS" id="5Tr1VsJLqqO" role="2VODD2">
+                <node concept="3clFbF" id="5Tr1VsJLqqP" role="3cqZAp">
+                  <node concept="2OqwBi" id="5Tr1VsJLqqQ" role="3clFbG">
+                    <node concept="30H73N" id="5Tr1VsJLqqR" role="2Oq$k0" />
+                    <node concept="3Tsc0h" id="5Tr1VsJLZux" role="2OqNvi">
+                      <ref role="3TtcxE" to="yvgz:3eP8Zudp5G8" resolve="data_ports" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="17Uvod" id="5Tr1VsJLqqT" role="lGtFl">
+            <property role="2qtEX9" value="name" />
+            <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+            <node concept="3zFVjK" id="5Tr1VsJLqqU" role="3zH0cK">
+              <node concept="3clFbS" id="5Tr1VsJLqqV" role="2VODD2">
+                <node concept="3cpWs8" id="5Tr1VsJLqqW" role="3cqZAp">
+                  <node concept="3cpWsn" id="5Tr1VsJLqqX" role="3cpWs9">
+                    <property role="TrG5h" value="argString" />
+                    <node concept="17QB3L" id="5Tr1VsJLqqY" role="1tU5fm" />
+                    <node concept="Xl_RD" id="5Tr1VsJLqqZ" role="33vP2m">
+                      <property role="Xl_RC" value="" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="5Tr1VsJLqr0" role="3cqZAp">
+                  <node concept="3clFbS" id="5Tr1VsJLqr1" role="3clFbx">
+                    <node concept="3clFbF" id="5Tr1VsJLqr2" role="3cqZAp">
+                      <node concept="d57v9" id="5Tr1VsJLqr3" role="3clFbG">
+                        <node concept="Xl_RD" id="5Tr1VsJLqr4" role="37vLTx">
+                          <property role="Xl_RC" value=", " />
+                        </node>
+                        <node concept="37vLTw" id="5Tr1VsJLqr5" role="37vLTJ">
+                          <ref role="3cqZAo" node="5Tr1VsJLqqX" resolve="argString" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3eOSWO" id="5Tr1VsJLqr6" role="3clFbw">
+                    <node concept="3cmrfG" id="5Tr1VsJLqr7" role="3uHU7w">
+                      <property role="3cmrfH" value="0" />
+                    </node>
+                    <node concept="2OqwBi" id="5Tr1VsJLqr8" role="3uHU7B">
+                      <node concept="1iwH7S" id="5Tr1VsJLqr9" role="2Oq$k0" />
+                      <node concept="1qCSth" id="5Tr1VsJLqra" role="2OqNvi">
+                        <property role="1qCSqd" value="dataPortCount" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="5Tr1VsJLqrb" role="3cqZAp">
+                  <node concept="d57v9" id="5Tr1VsJLqrc" role="3clFbG">
+                    <node concept="3cpWs3" id="5Tr1VsJLqrd" role="37vLTx">
+                      <node concept="Xl_RD" id="5Tr1VsJLqre" role="3uHU7w">
+                        <property role="Xl_RC" value=" " />
+                      </node>
+                      <node concept="2OqwBi" id="5Tr1VsJLqrf" role="3uHU7B">
+                        <node concept="30H73N" id="5Tr1VsJLqrg" role="2Oq$k0" />
+                        <node concept="3TrEf2" id="5Tr1VsJLqrh" role="2OqNvi">
+                          <ref role="3Tt5mk" to="yvgz:6po$YwiVDtx" resolve="type" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="37vLTw" id="5Tr1VsJLqri" role="37vLTJ">
+                      <ref role="3cqZAo" node="5Tr1VsJLqqX" resolve="argString" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="5Tr1VsJLqrj" role="3cqZAp">
+                  <node concept="3clFbS" id="5Tr1VsJLqrk" role="3clFbx">
+                    <node concept="3clFbF" id="5Tr1VsJLqrl" role="3cqZAp">
+                      <node concept="d57v9" id="5Tr1VsJLqrm" role="3clFbG">
+                        <node concept="Xl_RD" id="5Tr1VsJLqrn" role="37vLTx">
+                          <property role="Xl_RC" value="const " />
+                        </node>
+                        <node concept="37vLTw" id="5Tr1VsJLqro" role="37vLTJ">
+                          <ref role="3cqZAo" node="5Tr1VsJLqqX" resolve="argString" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="5Tr1VsJLqrp" role="3clFbw">
+                    <node concept="2OqwBi" id="5Tr1VsJLqrq" role="2Oq$k0">
+                      <node concept="30H73N" id="5Tr1VsJLqrr" role="2Oq$k0" />
+                      <node concept="3TrcHB" id="5Tr1VsJLqrs" role="2OqNvi">
+                        <ref role="3TsBF5" to="yvgz:6po$YwiVCCu" resolve="direction" />
+                      </node>
+                    </node>
+                    <node concept="21noJN" id="5Tr1VsJLqrt" role="2OqNvi">
+                      <node concept="21nZrQ" id="5Tr1VsJLqru" role="21noJM">
+                        <ref role="21nZrZ" to="yvgz:6po$YwiVCCm" resolve="In" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="5Tr1VsJLqrv" role="3cqZAp">
+                  <node concept="d57v9" id="5Tr1VsJLqrw" role="3clFbG">
+                    <node concept="3cpWs3" id="5Tr1VsJLqrx" role="37vLTx">
+                      <node concept="Xl_RD" id="5Tr1VsJLqry" role="3uHU7B">
+                        <property role="Xl_RC" value="*" />
+                      </node>
+                      <node concept="2OqwBi" id="5Tr1VsJLqrz" role="3uHU7w">
+                        <node concept="30H73N" id="5Tr1VsJLqr$" role="2Oq$k0" />
+                        <node concept="3TrcHB" id="5Tr1VsJLqr_" role="2OqNvi">
+                          <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="37vLTw" id="5Tr1VsJLqrA" role="37vLTJ">
+                      <ref role="3cqZAo" node="5Tr1VsJLqqX" resolve="argString" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs6" id="5Tr1VsJLqrB" role="3cqZAp">
+                  <node concept="37vLTw" id="5Tr1VsJLqrC" role="3cqZAk">
+                    <ref role="3cqZAo" node="5Tr1VsJLqqX" resolve="argString" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2EixSi" id="5Tr1VsJLqqH" role="2EinRH" />
+        <node concept="356sEF" id="5Tr1VsJLEGD" role="356sEH">
+          <property role="TrG5h" value=")" />
+        </node>
+      </node>
+      <node concept="raruj" id="5Tr1VsJLpp$" role="lGtFl" />
+    </node>
+  </node>
+  <node concept="13MO4I" id="5Tr1VsJNE2J">
+    <property role="TrG5h" value="include_FunctionCallParams" />
+    <ref role="3gUMe" to="yvgz:3eP8Zudp5G4" resolve="FunctionBlock" />
+    <node concept="356WMU" id="5Tr1VsJNE2L" role="13RCb5">
+      <node concept="raruj" id="5Tr1VsJNE2N" role="lGtFl" />
+    </node>
+  </node>
+</model>
+

--- a/languages/Algorithm_CGenerator/generator/templates/main@generator.mps
+++ b/languages/Algorithm_CGenerator/generator/templates/main@generator.mps
@@ -596,9 +596,6 @@
             <ref role="v9R2y" node="5Tr1VsJKqPj" resolve="switch_FunctionCall" />
           </node>
         </node>
-        <node concept="356sEF" id="5Tr1VsJDHZu" role="356sEH">
-          <property role="TrG5h" value=";" />
-        </node>
         <node concept="2EixSi" id="5Tr1VsJDHYE" role="2EinRH" />
         <node concept="1WS0z7" id="5Tr1VsJDHZz" role="lGtFl">
           <node concept="3JmXsc" id="5Tr1VsJDHZ$" role="3Jn$fo">
@@ -1165,7 +1162,7 @@
           </node>
         </node>
         <node concept="356sEF" id="5Tr1VsJMgP8" role="356sEH">
-          <property role="TrG5h" value=")" />
+          <property role="TrG5h" value=");" />
         </node>
       </node>
       <node concept="raruj" id="5Tr1VsJEoGu" role="lGtFl" />

--- a/solutions/Algorithm.sandbox/models/Algorithm.sandbox.mps
+++ b/solutions/Algorithm.sandbox/models/Algorithm.sandbox.mps
@@ -4,6 +4,7 @@
   <languages>
     <use id="a8f70f9e-ef01-499f-885c-c79273fa1695" name="Algorithm" version="0" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="9" />
+    <engage id="8d7c3baa-c6d4-442a-843a-34b7b957af1e" name="Algorithm_CGenerator" />
   </languages>
   <imports />
   <registry>

--- a/solutions/Algorithm.sandbox/models/Algorithm.sandbox.mps
+++ b/solutions/Algorithm.sandbox/models/Algorithm.sandbox.mps
@@ -53,6 +53,10 @@
         <property id="7374807014778505758" name="direction" index="1OHxBQ" />
         <child id="7374807014778509153" name="type" index="1OHwi9" />
       </concept>
+      <concept id="6197317434201432145" name="Algorithm.structure.DataBlockContainer" flags="ng" index="1RU2Ge">
+        <child id="6197317434201432148" name="closures" index="1RU2Gb" />
+        <child id="6197317434201432146" name="data_blocks" index="1RU2Gd" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
@@ -327,6 +331,97 @@
       <node concept="1pt3V6" id="3EtQu_yvpg" role="1OHzVH">
         <property role="TrG5h" value="kp" />
         <property role="2_BrWT" value="3EtQu_uj5i/Out" />
+      </node>
+    </node>
+  </node>
+  <node concept="1u3Uyy" id="44Cv2OMEdIf">
+    <property role="TrG5h" value="testDataContainer" />
+    <node concept="1OHxBB" id="44Cv2OMIBDP" role="3SlQUq">
+      <ref role="1OHxBS" node="44Cv2OMIBDG" resolve="funcContainerPort" />
+      <ref role="1OHyup" node="44Cv2OMFVOU" resolve="parent_a_port" />
+    </node>
+    <node concept="1OHxBU" id="44Cv2OMIBDG" role="2YOnzZ">
+      <property role="TrG5h" value="funcContainerPort" />
+      <property role="1OHxBQ" value="6po$YwiVCCm/In" />
+      <node concept="10P55v" id="44Cv2OMIBDM" role="1OHwi9" />
+    </node>
+    <node concept="1RU2Ge" id="44Cv2OMEdIi" role="3SlQUm">
+      <property role="TrG5h" value="parentContainer" />
+      <node concept="1OHxBB" id="44Cv2OMFVPl" role="1RU2Gb">
+        <ref role="1OHxBS" node="44Cv2OMFVON" resolve="c_port" />
+        <ref role="1OHyup" node="44Cv2OMFVPa" resolve="parent_c_port" />
+      </node>
+      <node concept="1OHxBB" id="44Cv2OMFVPq" role="1RU2Gb">
+        <ref role="1OHxBS" node="44Cv2OMFVIU" resolve="child_port_a" />
+        <ref role="1OHyup" node="44Cv2OMFVOU" resolve="parent_a_port" />
+      </node>
+      <node concept="1OHxBB" id="44Cv2OMFVPw" role="1RU2Gb">
+        <ref role="1OHxBS" node="44Cv2OMFVJ9" resolve="child_port_b" />
+        <ref role="1OHyup" node="44Cv2OMFVP1" resolve="parent_b_port" />
+      </node>
+      <node concept="1OHxBU" id="44Cv2OMFVOU" role="1ptsVk">
+        <property role="TrG5h" value="parent_a_port" />
+        <property role="1OHxBQ" value="6po$YwiVCCq/InOut" />
+        <node concept="10P55v" id="44Cv2OMFVOY" role="1OHwi9" />
+      </node>
+      <node concept="1OHxBU" id="44Cv2OMFVP1" role="1ptsVk">
+        <property role="TrG5h" value="parent_b_port" />
+        <property role="1OHxBQ" value="6po$YwiVCCn/Out" />
+        <node concept="10P55v" id="44Cv2OMFVP7" role="1OHwi9" />
+      </node>
+      <node concept="1OHxBU" id="44Cv2OMFVPa" role="1ptsVk">
+        <property role="TrG5h" value="parent_c_port" />
+        <property role="1OHxBQ" value="6po$YwiVCCq/InOut" />
+        <node concept="10P55v" id="44Cv2OMFVPi" role="1OHwi9" />
+      </node>
+      <node concept="1RU2Ge" id="44Cv2OMEdIn" role="1RU2Gd">
+        <property role="TrG5h" value="childContainer" />
+        <node concept="1OHxBU" id="44Cv2OMFVIU" role="1ptsVk">
+          <property role="TrG5h" value="child_port_a" />
+          <property role="1OHxBQ" value="6po$YwiVCCq/InOut" />
+          <node concept="10P55v" id="44Cv2OMFVJ4" role="1OHwi9" />
+        </node>
+        <node concept="1OHxBU" id="44Cv2OMFVJ9" role="1ptsVk">
+          <property role="TrG5h" value="child_port_b" />
+          <property role="1OHxBQ" value="6po$YwiVCCn/Out" />
+          <node concept="10P55v" id="44Cv2OMFVJf" role="1OHwi9" />
+        </node>
+        <node concept="1OHxBB" id="44Cv2OMEZZq" role="1RU2Gb">
+          <ref role="1OHxBS" node="44Cv2OMFVIU" resolve="child_port_a" />
+          <ref role="1OHyup" node="44Cv2OMEdIA" resolve="a_port" />
+        </node>
+        <node concept="2_B1M0" id="44Cv2OMEdIs" role="1RU2Gd">
+          <property role="TrG5h" value="a" />
+          <node concept="1OHxBU" id="44Cv2OMEdIA" role="1ptsVk">
+            <property role="TrG5h" value="a_port" />
+            <property role="1OHxBQ" value="6po$YwiVCCq/InOut" />
+            <node concept="10P55v" id="44Cv2OMEdIE" role="1OHwi9" />
+          </node>
+        </node>
+        <node concept="2_B1M0" id="44Cv2OMEdIy" role="1RU2Gd">
+          <property role="TrG5h" value="b" />
+          <node concept="1OHxBU" id="44Cv2OMEdIH" role="1ptsVk">
+            <property role="TrG5h" value="b_port" />
+            <property role="1OHxBQ" value="6po$YwiVCCn/Out" />
+            <node concept="10P55v" id="44Cv2OMEdIL" role="1OHwi9" />
+          </node>
+        </node>
+      </node>
+      <node concept="2_B1M0" id="44Cv2OMFVO$" role="1RU2Gd">
+        <property role="TrG5h" value="c" />
+        <node concept="1OHxBU" id="44Cv2OMFVON" role="1ptsVk">
+          <property role="TrG5h" value="c_port" />
+          <property role="1OHxBQ" value="6po$YwiVCCq/InOut" />
+          <node concept="10P55v" id="44Cv2OMFVOR" role="1OHwi9" />
+        </node>
+      </node>
+    </node>
+    <node concept="2_B1M0" id="5QQcZL$IhTP" role="3SlQUm">
+      <property role="TrG5h" value="emptyBlock" />
+      <node concept="1OHxBU" id="5QQcZL$Ii93" role="1ptsVk">
+        <property role="TrG5h" value="pInt" />
+        <property role="1OHxBQ" value="6po$YwiVCCm/In" />
+        <node concept="10Oyi0" id="5QQcZL$Ii97" role="1OHwi9" />
       </node>
     </node>
   </node>


### PR DESCRIPTION
The main purpose of this PR is to extract `algorithm-dsl` specific generation steps to a separate generation language in this repository. Other languages which use `algorithm-dsl` may then have their own generation language to extend upon the generators here.

However, there are unfortunately also these changes unrelated to the PR/branch, but would be too much work to untangle with Git:
* split generation into header and source file
* generate structs for `DataBlockContainer`'s, handle the case where they contain each other
* add constraints for `DataPort`'s
