### PR TITLE
generate function schedules correctly

### DIFF
--- a/languages/Algorithm/models/Algorithm.behavior.mps
+++ b/languages/Algorithm/models/Algorithm.behavior.mps
@@ -33,9 +33,6 @@
       <concept id="1225194691553" name="jetbrains.mps.lang.behavior.structure.ThisNodeExpression" flags="nn" index="13iPFW" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
-      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
-        <child id="1082485599096" name="statements" index="9aQI4" />
-      </concept>
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
@@ -51,9 +48,6 @@
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
       </concept>
-      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
-        <property id="1070475926801" name="value" index="Xl_RC" />
-      </concept>
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
@@ -64,7 +58,6 @@
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
-      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -79,7 +72,6 @@
       </concept>
       <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
-        <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
         <child id="1068580123160" name="condition" index="3clFbw" />
         <child id="1068580123161" name="ifTrue" index="3clFbx" />
         <child id="1206060520071" name="elsifClauses" index="3eNLev" />
@@ -87,7 +79,6 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
-      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
       </concept>
@@ -482,91 +473,6 @@
         </node>
         <node concept="x79VA" id="2FsRs4zDsYT" role="3nqlJM">
           <property role="x79VB" value="port of DataBlok instance" />
-        </node>
-      </node>
-    </node>
-    <node concept="13i0hz" id="7VOfr8WpcKN" role="13h7CS">
-      <property role="TrG5h" value="getVariableName" />
-      <node concept="3Tm1VV" id="7VOfr8WpcKO" role="1B3o_S" />
-      <node concept="17QB3L" id="7VOfr8WpcNY" role="3clF45" />
-      <node concept="3clFbS" id="7VOfr8WpcKQ" role="3clF47">
-        <node concept="3clFbJ" id="5PE55GMNHrK" role="3cqZAp">
-          <node concept="3clFbS" id="5PE55GMNHrL" role="3clFbx">
-            <node concept="3cpWs8" id="5PE55GMNHrM" role="3cqZAp">
-              <node concept="3cpWsn" id="5PE55GMNHrN" role="3cpWs9">
-                <property role="TrG5h" value="connectedData" />
-                <node concept="3Tqbb2" id="5PE55GMNHrO" role="1tU5fm">
-                  <ref role="ehGHo" to="yvgz:29RmJoXeePk" resolve="DataBlock" />
-                </node>
-                <node concept="1PxgMI" id="5PE55GMNHrP" role="33vP2m">
-                  <property role="1BlNFB" value="true" />
-                  <node concept="chp4Y" id="5PE55GMNHrQ" role="3oSUPX">
-                    <ref role="cht4Q" to="yvgz:29RmJoXeePk" resolve="DataBlock" />
-                  </node>
-                  <node concept="2OqwBi" id="5PE55GMNHrR" role="1m5AlR">
-                    <node concept="13iPFW" id="7VOfr8Wpef3" role="2Oq$k0" />
-                    <node concept="1mfA1w" id="5PE55GMNHrV" role="2OqNvi" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3cpWs6" id="7VOfr8WpdsE" role="3cqZAp">
-              <node concept="3cpWs3" id="1SzGUGQ5ux" role="3cqZAk">
-                <node concept="2OqwBi" id="1SzGUGQ5X1" role="3uHU7w">
-                  <node concept="13iPFW" id="1SzGUGQ5AN" role="2Oq$k0" />
-                  <node concept="3TrcHB" id="1SzGUGQ695" role="2OqNvi">
-                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                  </node>
-                </node>
-                <node concept="3cpWs3" id="1SzGUGQ4Cp" role="3uHU7B">
-                  <node concept="2OqwBi" id="7VOfr8WpdHp" role="3uHU7B">
-                    <node concept="37vLTw" id="7VOfr8Wpdvw" role="2Oq$k0">
-                      <ref role="3cqZAo" node="5PE55GMNHrN" resolve="connectedData" />
-                    </node>
-                    <node concept="3TrcHB" id="7VOfr8WpdQ6" role="2OqNvi">
-                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                    </node>
-                  </node>
-                  <node concept="Xl_RD" id="1SzGUGQ4LF" role="3uHU7w">
-                    <property role="Xl_RC" value="_" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="2OqwBi" id="5PE55GMNHs4" role="3clFbw">
-            <node concept="2OqwBi" id="5PE55GMNHs5" role="2Oq$k0">
-              <node concept="13iPFW" id="7VOfr8Wpdk2" role="2Oq$k0" />
-              <node concept="1mfA1w" id="5PE55GMNHs9" role="2OqNvi" />
-            </node>
-            <node concept="1mIQ4w" id="5PE55GMNHsa" role="2OqNvi">
-              <node concept="chp4Y" id="5PE55GMNHsb" role="cj9EA">
-                <ref role="cht4Q" to="yvgz:29RmJoXeePk" resolve="DataBlock" />
-              </node>
-            </node>
-          </node>
-          <node concept="9aQIb" id="6TAIVwhBQhI" role="9aQIa">
-            <node concept="3clFbS" id="6TAIVwhBQhJ" role="9aQI4">
-              <node concept="3cpWs6" id="6TAIVwhBQhK" role="3cqZAp">
-                <node concept="2OqwBi" id="6TAIVwhBQhL" role="3cqZAk">
-                  <node concept="13iPFW" id="6TAIVwhBQhM" role="2Oq$k0" />
-                  <node concept="3TrcHB" id="6TAIVwhBQhN" role="2OqNvi">
-                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="P$JXv" id="7VOfr8Wpj_d" role="lGtFl">
-        <node concept="TZ5HA" id="7VOfr8Wpj_e" role="TZ5H$">
-          <node concept="1dT_AC" id="7VOfr8Wpj_f" role="1dT_Ay">
-            <property role="1dT_AB" value="get the appropriate variable name for the port" />
-          </node>
-        </node>
-        <node concept="x79VA" id="7VOfr8Wpj_g" role="3nqlJM">
-          <property role="x79VB" value="if parent is DataBlock -&gt; datablock name +" />
         </node>
       </node>
     </node>

--- a/languages/Algorithm/models/Algorithm.structure.mps
+++ b/languages/Algorithm/models/Algorithm.structure.mps
@@ -145,8 +145,8 @@
     <property role="TrG5h" value="SchedulerBlock" />
     <property role="R5$K7" value="true" />
     <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
-    <node concept="PrWs8" id="29RmJoXeePm" role="PzmwI">
-      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
+    <node concept="PrWs8" id="58QN4$b4wid" role="PzmwI">
+      <ref role="PrY4T" to="tpee:hCUYCKd" resolve="IValidIdentifier" />
     </node>
     <node concept="1TJgyj" id="6jvQBgXG1ad" role="1TKVEi">
       <property role="IQ2ns" value="7268768516385280653" />

--- a/languages/Algorithm_CGenerator/generator/templates/main@generator.mps
+++ b/languages/Algorithm_CGenerator/generator/templates/main@generator.mps
@@ -83,7 +83,9 @@
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
     </language>
     <language id="b401a680-8325-4110-8fd3-84331ff25bef" name="jetbrains.mps.lang.generator">
-      <concept id="1510949579266781519" name="jetbrains.mps.lang.generator.structure.TemplateCallMacro" flags="ln" index="5jKBG" />
+      <concept id="1510949579266781519" name="jetbrains.mps.lang.generator.structure.TemplateCallMacro" flags="ln" index="5jKBG">
+        <child id="1510949579266801461" name="sourceNodeQuery" index="5jGum" />
+      </concept>
       <concept id="1095416546421" name="jetbrains.mps.lang.generator.structure.MappingConfiguration" flags="ig" index="bUwia">
         <child id="1167514678247" name="rootMappingRule" index="3lj3bC" />
       </concept>
@@ -101,6 +103,7 @@
       <concept id="1095672379244" name="jetbrains.mps.lang.generator.structure.TemplateFragment" flags="ng" index="raruj" />
       <concept id="1722980698497626400" name="jetbrains.mps.lang.generator.structure.ITemplateCall" flags="ng" index="v9R3L">
         <reference id="1722980698497626483" name="template" index="v9R2y" />
+        <child id="1722980698497626405" name="actualArgument" index="v9R3O" />
       </concept>
       <concept id="1167169188348" name="jetbrains.mps.lang.generator.structure.TemplateFunctionParameter_sourceNode" flags="nn" index="30H73N" />
       <concept id="1167169308231" name="jetbrains.mps.lang.generator.structure.BaseMappingRule" flags="ng" index="30H$t8">
@@ -120,11 +123,17 @@
       <concept id="1167514355419" name="jetbrains.mps.lang.generator.structure.Root_MappingRule" flags="lg" index="3lhOvk">
         <reference id="1167514355421" name="template" index="3lhOvi" />
       </concept>
+      <concept id="982871510064032177" name="jetbrains.mps.lang.generator.structure.IParameterizedTemplate" flags="ng" index="1s_3nv">
+        <child id="982871510064032342" name="parameter" index="1s_3oS" />
+      </concept>
       <concept id="982871510068000147" name="jetbrains.mps.lang.generator.structure.TemplateSwitchMacro" flags="lg" index="1sPUBX">
         <child id="982871510068000158" name="sourceNodeQuery" index="1sPUBK" />
       </concept>
       <concept id="1167756080639" name="jetbrains.mps.lang.generator.structure.PropertyMacro_GetPropertyValue" flags="in" index="3zFVjK" />
       <concept id="1167951910403" name="jetbrains.mps.lang.generator.structure.SourceSubstituteMacro_SourceNodesQuery" flags="in" index="3JmXsc" />
+      <concept id="1805153994415891174" name="jetbrains.mps.lang.generator.structure.TemplateParameterDeclaration" flags="ng" index="1N15co">
+        <child id="1805153994415893199" name="type" index="1N15GL" />
+      </concept>
       <concept id="1168024337012" name="jetbrains.mps.lang.generator.structure.SourceSubstituteMacro_SourceNodeQuery" flags="in" index="3NFfHV" />
       <concept id="1118786554307" name="jetbrains.mps.lang.generator.structure.LoopMacro" flags="ln" index="1WS0z7">
         <property id="7430509679011668804" name="counterVarName" index="1qytDF" />
@@ -138,6 +147,9 @@
       </concept>
     </language>
     <language id="d7706f63-9be2-479c-a3da-ae92af1e64d5" name="jetbrains.mps.lang.generator.generationContext">
+      <concept id="5190093307972723402" name="jetbrains.mps.lang.generator.generationContext.structure.GenerationContextOp_ParameterRef" flags="nn" index="3cR$yn">
+        <reference id="5190093307972736266" name="parameter" index="3cRzXn" />
+      </concept>
       <concept id="1216860049635" name="jetbrains.mps.lang.generator.generationContext.structure.TemplateFunctionParameter_generationContext" flags="nn" index="1iwH7S" />
       <concept id="7430509679014182526" name="jetbrains.mps.lang.generator.generationContext.structure.GenerationContextOp_ContextVarRef" flags="ng" index="1qCSth">
         <property id="7430509679014182818" name="contextVarName" index="1qCSqd" />
@@ -324,6 +336,48 @@
       <node concept="356sEK" id="5Tr1VsJD$ML" role="383Ya9">
         <node concept="2EixSi" id="5Tr1VsJD$MN" role="2EinRH" />
       </node>
+      <node concept="356sEK" id="58QN4$b2wH5" role="383Ya9">
+        <node concept="356sEF" id="58QN4$b2wH6" role="356sEH">
+          <property role="TrG5h" value="/* Schedules */" />
+        </node>
+        <node concept="2EixSi" id="58QN4$b2wH7" role="2EinRH" />
+      </node>
+      <node concept="356sEK" id="58QN4$b2wVv" role="383Ya9">
+        <node concept="356sEF" id="58QN4$b2AyB" role="356sEH">
+          <property role="TrG5h" value="schedules" />
+        </node>
+        <node concept="2EixSi" id="58QN4$b2wVx" role="2EinRH" />
+        <node concept="1WS0z7" id="58QN4$b2OkA" role="lGtFl">
+          <node concept="3JmXsc" id="58QN4$b2OkB" role="3Jn$fo">
+            <node concept="3clFbS" id="58QN4$b2OkC" role="2VODD2">
+              <node concept="3clFbF" id="58QN4$b2Ozz" role="3cqZAp">
+                <node concept="2OqwBi" id="58QN4$b2OPe" role="3clFbG">
+                  <node concept="30H73N" id="58QN4$b2Ozy" role="2Oq$k0" />
+                  <node concept="3Tsc0h" id="58QN4$b2Pea" role="2OqNvi">
+                    <ref role="3TtcxE" to="yvgz:4iWYoaWUTsh" resolve="scheduler_blocks" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="5jKBG" id="58QN4$b2BYk" role="lGtFl">
+          <ref role="v9R2y" node="58QN4$b2$hR" resolve="include_SchedulerBlock" />
+          <node concept="1PxgMI" id="58QN4$b2OhQ" role="v9R3O">
+            <property role="1BlNFB" value="true" />
+            <node concept="chp4Y" id="58QN4$b2Oja" role="3oSUPX">
+              <ref role="cht4Q" to="yvgz:7YUYw4xHlaz" resolve="FunctionBlockContainer" />
+            </node>
+            <node concept="2OqwBi" id="58QN4$b2NX1" role="1m5AlR">
+              <node concept="30H73N" id="58QN4$b2Ntr" role="2Oq$k0" />
+              <node concept="1mfA1w" id="58QN4$b2Oax" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="356sEK" id="58QN4$b2AyH" role="383Ya9">
+        <node concept="2EixSi" id="58QN4$b2AyJ" role="2EinRH" />
+      </node>
       <node concept="356sEK" id="5Tr1VsJD$P9" role="383Ya9">
         <node concept="356sEF" id="5Tr1VsJD$Pa" role="356sEH">
           <property role="TrG5h" value="/* define function container */" />
@@ -356,7 +410,7 @@
         <node concept="356sEF" id="5Tr1VsJD$VT" role="356sEH">
           <property role="TrG5h" value="void functionDef(params)" />
           <node concept="5jKBG" id="5Tr1VsJM0Xw" role="lGtFl">
-            <ref role="v9R2y" node="5Tr1VsJLpoy" resolve="include_FunctionDefParams" />
+            <ref role="v9R2y" node="5Tr1VsJLpoy" resolve="include_FunctionDeclareArgs" />
           </node>
         </node>
         <node concept="356sEF" id="5Tr1VsJD_2Q" role="356sEH">
@@ -459,7 +513,7 @@
     </node>
   </node>
   <node concept="13MO4I" id="5Tr1VsJD$im">
-    <property role="TrG5h" value="reduce_EmptyFunctionDef" />
+    <property role="TrG5h" value="reduce_EmptyFunctionDeclaration" />
     <ref role="3gUMe" to="yvgz:29RmJoXeePh" resolve="EmptyFunctionBlock" />
     <node concept="356WMU" id="5Tr1VsJD$io" role="13RCb5">
       <node concept="356sEK" id="2FsRs4zCSHt" role="383Ya9">
@@ -489,7 +543,7 @@
         <node concept="356sEF" id="5Tr1VsJLq3_" role="356sEH">
           <property role="TrG5h" value="params" />
           <node concept="5jKBG" id="5Tr1VsJM0XP" role="lGtFl">
-            <ref role="v9R2y" node="5Tr1VsJLpoy" resolve="include_FunctionDefParams" />
+            <ref role="v9R2y" node="5Tr1VsJLpoy" resolve="include_FunctionDeclareArgs" />
           </node>
         </node>
       </node>
@@ -812,7 +866,7 @@
         <node concept="356sEF" id="5Tr1VsJMgP8" role="356sEH">
           <property role="TrG5h" value="params" />
           <node concept="5jKBG" id="1SzGUGPLmh" role="lGtFl">
-            <ref role="v9R2y" node="5Tr1VsJNE2J" resolve="include_FunctionCallParams" />
+            <ref role="v9R2y" node="5Tr1VsJNE2J" resolve="include_FunctionCallArgs" />
           </node>
         </node>
       </node>
@@ -871,7 +925,7 @@
       <property role="36QftV" value="true" />
       <ref role="30HIoZ" to="yvgz:29RmJoXeePh" resolve="EmptyFunctionBlock" />
       <node concept="j$656" id="5Tr1VsJKqPg" role="1lVwrX">
-        <ref role="v9R2y" node="5Tr1VsJD$im" resolve="reduce_EmptyFunctionDef" />
+        <ref role="v9R2y" node="5Tr1VsJD$im" resolve="reduce_EmptyFunctionDeclaration" />
       </node>
     </node>
   </node>
@@ -886,7 +940,7 @@
     </node>
   </node>
   <node concept="13MO4I" id="5Tr1VsJLpoy">
-    <property role="TrG5h" value="include_FunctionDefParams" />
+    <property role="TrG5h" value="include_FunctionDeclareArgs" />
     <ref role="3gUMe" to="yvgz:3eP8Zudp5G4" resolve="FunctionBlock" />
     <node concept="356WMU" id="5Tr1VsJLppm" role="13RCb5">
       <node concept="356sEK" id="5Tr1VsJLqqF" role="383Ya9">
@@ -1030,7 +1084,7 @@
     </node>
   </node>
   <node concept="13MO4I" id="5Tr1VsJNE2J">
-    <property role="TrG5h" value="include_FunctionCallParams" />
+    <property role="TrG5h" value="include_FunctionCallArgs" />
     <ref role="3gUMe" to="yvgz:3eP8Zudp5G4" resolve="FunctionBlock" />
     <node concept="356WMU" id="5Tr1VsJNE2L" role="13RCb5">
       <node concept="356sEK" id="1SzGUGPGMf" role="383Ya9">
@@ -1730,6 +1784,104 @@
           <node concept="2EixSi" id="58QN4$b28xv" role="2EinRH" />
         </node>
       </node>
+    </node>
+  </node>
+  <node concept="13MO4I" id="58QN4$b2$hR">
+    <property role="TrG5h" value="include_SchedulerBlock" />
+    <ref role="3gUMe" to="yvgz:29RmJoXeePl" resolve="SchedulerBlock" />
+    <node concept="1N15co" id="58QN4$b2Mji" role="1s_3oS">
+      <property role="TrG5h" value="parent" />
+      <node concept="3Tqbb2" id="58QN4$b2Mqs" role="1N15GL">
+        <ref role="ehGHo" to="yvgz:7YUYw4xHlaz" resolve="FunctionBlockContainer" />
+      </node>
+    </node>
+    <node concept="356WMU" id="58QN4$b2$hW" role="13RCb5">
+      <node concept="356sEK" id="58QN4$b2$mY" role="383Ya9">
+        <node concept="356sEF" id="58QN4$b2$mZ" role="356sEH">
+          <property role="TrG5h" value="void " />
+        </node>
+        <node concept="356sEF" id="58QN4$b2$n4" role="356sEH">
+          <property role="TrG5h" value="functionName" />
+          <node concept="17Uvod" id="58QN4$b2$om" role="lGtFl">
+            <property role="2qtEX9" value="name" />
+            <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+            <node concept="3zFVjK" id="58QN4$b2$on" role="3zH0cK">
+              <node concept="3clFbS" id="58QN4$b2$oo" role="2VODD2">
+                <node concept="3clFbF" id="58QN4$b2IMu" role="3cqZAp">
+                  <node concept="3cpWs3" id="58QN4$b2JG6" role="3clFbG">
+                    <node concept="2OqwBi" id="58QN4$b2Kki" role="3uHU7w">
+                      <node concept="30H73N" id="58QN4$b2K1L" role="2Oq$k0" />
+                      <node concept="3TrcHB" id="58QN4$b2Kux" role="2OqNvi">
+                        <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                      </node>
+                    </node>
+                    <node concept="3cpWs3" id="58QN4$b2KOM" role="3uHU7B">
+                      <node concept="Xl_RD" id="58QN4$b2KRe" role="3uHU7w">
+                        <property role="Xl_RC" value="_" />
+                      </node>
+                      <node concept="2OqwBi" id="58QN4$b2J7b" role="3uHU7B">
+                        <node concept="2OqwBi" id="58QN4$b2YnE" role="2Oq$k0">
+                          <node concept="1iwH7S" id="58QN4$b2Y7G" role="2Oq$k0" />
+                          <node concept="3cR$yn" id="58QN4$b2Yz_" role="2OqNvi">
+                            <ref role="3cRzXn" node="58QN4$b2Mji" resolve="parent" />
+                          </node>
+                        </node>
+                        <node concept="3TrcHB" id="58QN4$b2Jlu" role="2OqNvi">
+                          <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="356sEF" id="58QN4$b2$nb" role="356sEH">
+          <property role="TrG5h" value="(params)" />
+          <node concept="5jKBG" id="58QN4$b37bz" role="lGtFl">
+            <ref role="v9R2y" node="5Tr1VsJLpoy" resolve="include_FunctionDeclareArgs" />
+            <node concept="3NFfHV" id="58QN4$b37nP" role="5jGum">
+              <node concept="3clFbS" id="58QN4$b37nQ" role="2VODD2">
+                <node concept="3clFbF" id="58QN4$b37pM" role="3cqZAp">
+                  <node concept="2OqwBi" id="58QN4$b37zN" role="3clFbG">
+                    <node concept="1iwH7S" id="58QN4$b37pL" role="2Oq$k0" />
+                    <node concept="3cR$yn" id="58QN4$b37BI" role="2OqNvi">
+                      <ref role="3cRzXn" node="58QN4$b2Mji" resolve="parent" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="356sEF" id="58QN4$b2$ng" role="356sEH">
+          <property role="TrG5h" value=" {" />
+        </node>
+        <node concept="2EixSi" id="58QN4$b2$n0" role="2EinRH" />
+      </node>
+      <node concept="356sEK" id="58QN4$b2$nN" role="383Ya9">
+        <node concept="356sEQ" id="58QN4$b2$o9" role="356sEH">
+          <property role="333NGx" value="  " />
+          <node concept="356sEK" id="58QN4$b2$o6" role="383Ya9">
+            <node concept="2EixSi" id="58QN4$b2$o8" role="2EinRH" />
+            <node concept="356sEF" id="58QN4$b2$nO" role="356sEH">
+              <property role="TrG5h" value="schedule" />
+              <node concept="1sPUBX" id="58QN4$b2$ok" role="lGtFl">
+                <ref role="v9R2y" node="5Tr1VsJJAo1" resolve="switch_SchedulerBlock" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2EixSi" id="58QN4$b2$nP" role="2EinRH" />
+      </node>
+      <node concept="356sEK" id="58QN4$b2$nz" role="383Ya9">
+        <node concept="356sEF" id="58QN4$b2$n$" role="356sEH">
+          <property role="TrG5h" value="}" />
+        </node>
+        <node concept="2EixSi" id="58QN4$b2$n_" role="2EinRH" />
+      </node>
+      <node concept="raruj" id="58QN4$b2$i2" role="lGtFl" />
     </node>
   </node>
 </model>

--- a/languages/Algorithm_CGenerator/generator/templates/main@generator.mps
+++ b/languages/Algorithm_CGenerator/generator/templates/main@generator.mps
@@ -378,119 +378,6 @@
       <node concept="356sEK" id="58QN4$b2AyH" role="383Ya9">
         <node concept="2EixSi" id="58QN4$b2AyJ" role="2EinRH" />
       </node>
-      <node concept="356sEK" id="5Tr1VsJD$P9" role="383Ya9">
-        <node concept="356sEF" id="5Tr1VsJD$Pa" role="356sEH">
-          <property role="TrG5h" value="/* define function container */" />
-        </node>
-        <node concept="2EixSi" id="5Tr1VsJD$Pb" role="2EinRH" />
-      </node>
-      <node concept="356sEK" id="5Tr1VsJD$VS" role="383Ya9">
-        <node concept="356sEF" id="5Tr1VsJNFK7" role="356sEH">
-          <property role="TrG5h" value="void " />
-        </node>
-        <node concept="356sEF" id="5Tr1VsJNFKd" role="356sEH">
-          <property role="TrG5h" value="functionName" />
-          <node concept="17Uvod" id="5Tr1VsJNFKk" role="lGtFl">
-            <property role="2qtEX9" value="name" />
-            <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
-            <node concept="3zFVjK" id="5Tr1VsJNFKl" role="3zH0cK">
-              <node concept="3clFbS" id="5Tr1VsJNFKm" role="2VODD2">
-                <node concept="3clFbF" id="5Tr1VsJNFOX" role="3cqZAp">
-                  <node concept="2OqwBi" id="5Tr1VsJNFVF" role="3clFbG">
-                    <node concept="30H73N" id="5Tr1VsJNFOW" role="2Oq$k0" />
-                    <node concept="3TrcHB" id="5Tr1VsJNFX7" role="2OqNvi">
-                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="356sEF" id="5Tr1VsJD$VT" role="356sEH">
-          <property role="TrG5h" value="void functionDef(params)" />
-          <node concept="5jKBG" id="5Tr1VsJM0Xw" role="lGtFl">
-            <ref role="v9R2y" node="5Tr1VsJLpoy" resolve="include_FunctionDeclareArgs" />
-          </node>
-        </node>
-        <node concept="356sEF" id="5Tr1VsJD_2Q" role="356sEH">
-          <property role="TrG5h" value=" {" />
-        </node>
-        <node concept="2EixSi" id="5Tr1VsJD$VU" role="2EinRH" />
-      </node>
-      <node concept="356sEK" id="5Tr1VsJD_9P" role="383Ya9">
-        <node concept="356sEQ" id="5Tr1VsJD_bm" role="356sEH">
-          <property role="333NGx" value="  " />
-          <node concept="356sEK" id="5Tr1VsJD_bj" role="383Ya9">
-            <node concept="2EixSi" id="5Tr1VsJD_bl" role="2EinRH" />
-            <node concept="356sEF" id="5Tr1VsJD_9Q" role="356sEH">
-              <property role="TrG5h" value="/* data blocks */" />
-            </node>
-          </node>
-          <node concept="356sEK" id="5QQcZL$IqyF" role="383Ya9">
-            <node concept="356sEF" id="5QQcZL$IqyG" role="356sEH">
-              <property role="TrG5h" value="type name" />
-            </node>
-            <node concept="2EixSi" id="5QQcZL$IqyH" role="2EinRH" />
-            <node concept="1WS0z7" id="5QQcZL$IqCN" role="lGtFl">
-              <node concept="3JmXsc" id="5QQcZL$IqCO" role="3Jn$fo">
-                <node concept="3clFbS" id="5QQcZL$IqCP" role="2VODD2">
-                  <node concept="3clFbF" id="5QQcZL$IqDn" role="3cqZAp">
-                    <node concept="2OqwBi" id="5QQcZL$IqS4" role="3clFbG">
-                      <node concept="30H73N" id="5QQcZL$IqDm" role="2Oq$k0" />
-                      <node concept="3Tsc0h" id="5QQcZL$Ir5m" role="2OqNvi">
-                        <ref role="3TtcxE" to="yvgz:4iWYoaWUTsk" resolve="data_blocks" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="1sPUBX" id="5QQcZL$Irkj" role="lGtFl">
-              <ref role="v9R2y" node="5QQcZL$HVDQ" resolve="switch_DataBlockVarDeclare" />
-            </node>
-          </node>
-          <node concept="356sEK" id="5QQcZL$I9pQ" role="383Ya9">
-            <node concept="2EixSi" id="5QQcZL$I9pS" role="2EinRH" />
-          </node>
-          <node concept="356sEK" id="5Tr1VsJDDFr" role="383Ya9">
-            <node concept="356sEF" id="5Tr1VsJDDFs" role="356sEH">
-              <property role="TrG5h" value="/* schedules */" />
-            </node>
-            <node concept="2EixSi" id="5Tr1VsJDDFt" role="2EinRH" />
-          </node>
-          <node concept="356sEK" id="5Tr1VsJDDFA" role="383Ya9">
-            <node concept="356sEF" id="5Tr1VsJDDFB" role="356sEH">
-              <property role="TrG5h" value="schedules" />
-              <node concept="1WS0z7" id="5Tr1VsJDEGY" role="lGtFl">
-                <node concept="3JmXsc" id="5Tr1VsJDEGZ" role="3Jn$fo">
-                  <node concept="3clFbS" id="5Tr1VsJDEH0" role="2VODD2">
-                    <node concept="3clFbF" id="5Tr1VsJDEJK" role="3cqZAp">
-                      <node concept="2OqwBi" id="5Tr1VsJDEXF" role="3clFbG">
-                        <node concept="30H73N" id="5Tr1VsJDEJJ" role="2Oq$k0" />
-                        <node concept="3Tsc0h" id="5Tr1VsJDF9y" role="2OqNvi">
-                          <ref role="3TtcxE" to="yvgz:4iWYoaWUTsh" resolve="scheduler_blocks" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="1sPUBX" id="5Tr1VsJJBD5" role="lGtFl">
-                <ref role="v9R2y" node="5Tr1VsJJAo1" resolve="switch_SchedulerBlock" />
-              </node>
-            </node>
-            <node concept="2EixSi" id="5Tr1VsJDDFC" role="2EinRH" />
-          </node>
-        </node>
-        <node concept="2EixSi" id="5Tr1VsJD_9R" role="2EinRH" />
-      </node>
-      <node concept="356sEK" id="5Tr1VsJD_2W" role="383Ya9">
-        <node concept="356sEF" id="5Tr1VsJD_2X" role="356sEH">
-          <property role="TrG5h" value="}" />
-        </node>
-        <node concept="2EixSi" id="5Tr1VsJD_2Y" role="2EinRH" />
-      </node>
     </node>
     <node concept="n94m4" id="5Tr1VsJDsui" role="lGtFl">
       <ref role="n9lRv" to="yvgz:7YUYw4xHlaz" resolve="FunctionBlockContainer" />
@@ -565,26 +452,7 @@
     <node concept="356WMU" id="5Tr1VsJDHh3" role="13RCb5">
       <node concept="356sEK" id="5Tr1VsJDHhb" role="383Ya9">
         <node concept="356sEF" id="5Tr1VsJDHhc" role="356sEH">
-          <property role="TrG5h" value="// fixed data flow schedule: " />
-        </node>
-        <node concept="356sEF" id="5Tr1VsJDHhh" role="356sEH">
-          <property role="TrG5h" value="name" />
-          <node concept="17Uvod" id="5Tr1VsJDHhk" role="lGtFl">
-            <property role="2qtEX9" value="name" />
-            <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
-            <node concept="3zFVjK" id="5Tr1VsJDHhl" role="3zH0cK">
-              <node concept="3clFbS" id="5Tr1VsJDHhm" role="2VODD2">
-                <node concept="3clFbF" id="5Tr1VsJDHlX" role="3cqZAp">
-                  <node concept="2OqwBi" id="5Tr1VsJDHzB" role="3clFbG">
-                    <node concept="30H73N" id="5Tr1VsJDHlW" role="2Oq$k0" />
-                    <node concept="3TrcHB" id="5Tr1VsJDHRr" role="2OqNvi">
-                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
+          <property role="TrG5h" value="// fixed data flow schedule" />
         </node>
         <node concept="2EixSi" id="5Tr1VsJDHhd" role="2EinRH" />
       </node>
@@ -882,26 +750,7 @@
         <node concept="356WMU" id="5Tr1VsJJAxL" role="gfFT$">
           <node concept="356sEK" id="5Tr1VsJJAxN" role="383Ya9">
             <node concept="356sEF" id="5Tr1VsJJAxO" role="356sEH">
-              <property role="TrG5h" value="// empty schedule: " />
-            </node>
-            <node concept="356sEF" id="5Tr1VsJJAxT" role="356sEH">
-              <property role="TrG5h" value="name" />
-              <node concept="17Uvod" id="5Tr1VsJJAxY" role="lGtFl">
-                <property role="2qtEX9" value="name" />
-                <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
-                <node concept="3zFVjK" id="5Tr1VsJJAxZ" role="3zH0cK">
-                  <node concept="3clFbS" id="5Tr1VsJJAy0" role="2VODD2">
-                    <node concept="3clFbF" id="5Tr1VsJJAAB" role="3cqZAp">
-                      <node concept="2OqwBi" id="5Tr1VsJJANB" role="3clFbG">
-                        <node concept="30H73N" id="5Tr1VsJJAAA" role="2Oq$k0" />
-                        <node concept="3TrcHB" id="5Tr1VsJJAXT" role="2OqNvi">
-                          <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
+              <property role="TrG5h" value="// empty schedule" />
             </node>
             <node concept="2EixSi" id="5Tr1VsJJAxP" role="2EinRH" />
           </node>
@@ -1863,6 +1712,43 @@
       <node concept="356sEK" id="58QN4$b2$nN" role="383Ya9">
         <node concept="356sEQ" id="58QN4$b2$o9" role="356sEH">
           <property role="333NGx" value="  " />
+          <node concept="356sEK" id="58QN4$b5ags" role="383Ya9">
+            <node concept="356sEF" id="58QN4$b5agt" role="356sEH">
+              <property role="TrG5h" value="/* data blocks */" />
+            </node>
+            <node concept="2EixSi" id="58QN4$b5agu" role="2EinRH" />
+          </node>
+          <node concept="356sEK" id="58QN4$b5agM" role="383Ya9">
+            <node concept="356sEF" id="58QN4$b5agN" role="356sEH">
+              <property role="TrG5h" value="type name" />
+            </node>
+            <node concept="2EixSi" id="58QN4$b5agO" role="2EinRH" />
+            <node concept="1WS0z7" id="58QN4$b5ahx" role="lGtFl">
+              <node concept="3JmXsc" id="58QN4$b5ahy" role="3Jn$fo">
+                <node concept="3clFbS" id="58QN4$b5ahz" role="2VODD2">
+                  <node concept="3clFbF" id="58QN4$b5akj" role="3cqZAp">
+                    <node concept="2OqwBi" id="58QN4$b5aPU" role="3clFbG">
+                      <node concept="2OqwBi" id="58QN4$b5awz" role="2Oq$k0">
+                        <node concept="1iwH7S" id="58QN4$b5aki" role="2Oq$k0" />
+                        <node concept="3cR$yn" id="58QN4$b5aAP" role="2OqNvi">
+                          <ref role="3cRzXn" node="58QN4$b2Mji" resolve="parent" />
+                        </node>
+                      </node>
+                      <node concept="3Tsc0h" id="58QN4$b5b3k" role="2OqNvi">
+                        <ref role="3TtcxE" to="yvgz:4iWYoaWUTsk" resolve="data_blocks" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1sPUBX" id="58QN4$b5b7C" role="lGtFl">
+              <ref role="v9R2y" node="5QQcZL$HVDQ" resolve="switch_DataBlockVarDeclare" />
+            </node>
+          </node>
+          <node concept="356sEK" id="58QN4$b5agg" role="383Ya9">
+            <node concept="2EixSi" id="58QN4$b5agi" role="2EinRH" />
+          </node>
           <node concept="356sEK" id="58QN4$b2$o6" role="383Ya9">
             <node concept="2EixSi" id="58QN4$b2$o8" role="2EinRH" />
             <node concept="356sEF" id="58QN4$b2$nO" role="356sEH">

--- a/languages/Algorithm_CGenerator/generator/templates/main@generator.mps
+++ b/languages/Algorithm_CGenerator/generator/templates/main@generator.mps
@@ -14,6 +14,9 @@
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
+        <child id="1082485599096" name="statements" index="9aQI4" />
+      </concept>
       <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
@@ -35,6 +38,7 @@
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
@@ -48,13 +52,17 @@
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
-      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
         <child id="1068580123160" name="condition" index="3clFbw" />
         <child id="1068580123161" name="ifTrue" index="3clFbx" />
+        <child id="1206060520071" name="elsifClauses" index="3eNLev" />
       </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
       </concept>
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
@@ -67,10 +75,17 @@
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1206060495898" name="jetbrains.mps.baseLanguage.structure.ElsifClause" flags="ng" index="3eNFk2">
+        <child id="1206060619838" name="condition" index="3eO9$A" />
+        <child id="1206060644605" name="statementList" index="3eOfB_" />
+      </concept>
       <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
         <child id="1079359253376" name="expression" index="1eOMHV" />
       </concept>
       <concept id="1081506762703" name="jetbrains.mps.baseLanguage.structure.GreaterThanExpression" flags="nn" index="3eOSWO" />
+      <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
+        <child id="1081516765348" name="expression" index="3fr31v" />
+      </concept>
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
@@ -133,11 +148,15 @@
         <child id="982871510068000158" name="sourceNodeQuery" index="1sPUBK" />
       </concept>
       <concept id="1167756080639" name="jetbrains.mps.lang.generator.structure.PropertyMacro_GetPropertyValue" flags="in" index="3zFVjK" />
+      <concept id="1167945743726" name="jetbrains.mps.lang.generator.structure.IfMacro_Condition" flags="in" index="3IZrLx" />
       <concept id="1167951910403" name="jetbrains.mps.lang.generator.structure.SourceSubstituteMacro_SourceNodesQuery" flags="in" index="3JmXsc" />
       <concept id="1805153994415891174" name="jetbrains.mps.lang.generator.structure.TemplateParameterDeclaration" flags="ng" index="1N15co">
         <child id="1805153994415893199" name="type" index="1N15GL" />
       </concept>
       <concept id="1168024337012" name="jetbrains.mps.lang.generator.structure.SourceSubstituteMacro_SourceNodeQuery" flags="in" index="3NFfHV" />
+      <concept id="1118773211870" name="jetbrains.mps.lang.generator.structure.IfMacro" flags="ln" index="1W57fq">
+        <child id="1167945861827" name="conditionFunction" index="3IZSJc" />
+      </concept>
       <concept id="1118786554307" name="jetbrains.mps.lang.generator.structure.LoopMacro" flags="ln" index="1WS0z7">
         <property id="7430509679011668804" name="counterVarName" index="1qytDF" />
         <child id="1167952069335" name="sourceNodesQuery" index="3Jn$fo" />
@@ -178,6 +197,11 @@
       </concept>
     </language>
     <language id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging">
+      <concept id="6332851714983831325" name="jetbrains.mps.baseLanguage.logging.structure.MsgStatement" flags="ng" index="2xdQw9">
+        <property id="6332851714983843871" name="severity" index="2xdLsb" />
+        <child id="5721587534047265374" name="message" index="9lYJi" />
+        <child id="5721587534047265375" name="throwable" index="9lYJj" />
+      </concept>
       <concept id="2034914114981261497" name="jetbrains.mps.baseLanguage.logging.structure.LogLowLevelStatement" flags="ng" index="RRSsy">
         <property id="2034914114981261751" name="severity" index="RRSoG" />
         <child id="2034914114981261755" name="throwable" index="RRSow" />
@@ -195,6 +219,7 @@
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
       <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
         <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
@@ -309,7 +334,7 @@
       </node>
       <node concept="356sEK" id="5Tr1VsJDuaY" role="383Ya9">
         <node concept="356sEF" id="5Tr1VsJDuaZ" role="356sEH">
-          <property role="TrG5h" value="/* define used functions */" />
+          <property role="TrG5h" value="/* declare functions */" />
         </node>
         <node concept="2EixSi" id="5Tr1VsJDub0" role="2EinRH" />
       </node>
@@ -333,7 +358,7 @@
           </node>
         </node>
         <node concept="1sPUBX" id="44Cv2OMJ4Ui" role="lGtFl">
-          <ref role="v9R2y" node="5Tr1VsJKqPb" resolve="switch_FunctionDef" />
+          <ref role="v9R2y" node="5Tr1VsJKqPb" resolve="switch_FunctionDeclare" />
         </node>
       </node>
       <node concept="356sEK" id="5Tr1VsJD$ML" role="383Ya9">
@@ -784,7 +809,7 @@
     </node>
   </node>
   <node concept="jVnub" id="5Tr1VsJKqPb">
-    <property role="TrG5h" value="switch_FunctionDef" />
+    <property role="TrG5h" value="switch_FunctionDeclare" />
     <node concept="3aamgX" id="5Tr1VsJKqPc" role="3aUrZf">
       <property role="36QftV" value="true" />
       <ref role="30HIoZ" to="yvgz:29RmJoXeePh" resolve="EmptyFunctionBlock" />
@@ -964,131 +989,79 @@
         <ref role="ehGHo" to="yvgz:7YUYw4xHlaz" resolve="FunctionBlockContainer" />
       </node>
     </node>
-    <node concept="356WMU" id="5Tr1VsJNE2L" role="13RCb5">
-      <node concept="356sEK" id="1SzGUGPGMf" role="383Ya9">
-        <node concept="356sEF" id="1SzGUGPGMg" role="356sEH">
+    <node concept="356WMU" id="7akAd_T$M4f" role="13RCb5">
+      <node concept="356sEK" id="7akAd_T$M4r" role="383Ya9">
+        <node concept="356sEF" id="7akAd_T$M5D" role="356sEH">
           <property role="TrG5h" value="(" />
         </node>
-        <node concept="356sEF" id="44Cv2OMCeyC" role="356sEH">
-          <property role="TrG5h" value="params" />
-          <node concept="1WS0z7" id="44Cv2OMCjL5" role="lGtFl">
+        <node concept="356sEK" id="7akAd_T$M6n" role="356sEH">
+          <node concept="2EixSi" id="7akAd_T$M6p" role="2EinRH" />
+          <node concept="356sEF" id="7akAd_T$M5I" role="356sEH">
+            <property role="TrG5h" value=", " />
+            <node concept="1W57fq" id="7akAd_T$Mtl" role="lGtFl">
+              <node concept="3IZrLx" id="7akAd_T$Mtm" role="3IZSJc">
+                <node concept="3clFbS" id="7akAd_T$Mtn" role="2VODD2">
+                  <node concept="3clFbF" id="7akAd_T$Mxn" role="3cqZAp">
+                    <node concept="3eOSWO" id="7akAd_T$NS7" role="3clFbG">
+                      <node concept="3cmrfG" id="7akAd_T$NT3" role="3uHU7w">
+                        <property role="3cmrfH" value="0" />
+                      </node>
+                      <node concept="2OqwBi" id="7akAd_T$MCm" role="3uHU7B">
+                        <node concept="1iwH7S" id="7akAd_T$Mxm" role="2Oq$k0" />
+                        <node concept="1qCSth" id="7akAd_T$MHi" role="2OqNvi">
+                          <property role="1qCSqd" value="portIndex" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="356sEF" id="7akAd_T$M6M" role="356sEH">
+            <property role="TrG5h" value="argument" />
+            <node concept="5jKBG" id="7akAd_T$T_j" role="lGtFl">
+              <ref role="v9R2y" node="7akAd_T$TvZ" resolve="include_ResolveDataConnection" />
+              <node concept="1PxgMI" id="7akAd_T$YzS" role="v9R3O">
+                <property role="1BlNFB" value="true" />
+                <node concept="chp4Y" id="7akAd_T$YAy" role="3oSUPX">
+                  <ref role="cht4Q" to="yvgz:3eP8Zudp5G4" resolve="FunctionBlock" />
+                </node>
+                <node concept="2OqwBi" id="7akAd_T$Y9E" role="1m5AlR">
+                  <node concept="30H73N" id="7akAd_T$TB2" role="2Oq$k0" />
+                  <node concept="1mfA1w" id="7akAd_T$YqO" role="2OqNvi" />
+                </node>
+              </node>
+              <node concept="v3LJS" id="7akAd_T$U0l" role="v9R3O">
+                <ref role="v3LJV" node="7akAd_TzOEr" resolve="parentFunction" />
+              </node>
+              <node concept="3clFbT" id="7akAd_TAphs" role="v9R3O">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+          <node concept="1WS0z7" id="7akAd_T$MdX" role="lGtFl">
             <property role="1qytDF" value="portIndex" />
-            <node concept="3JmXsc" id="44Cv2OMCjL6" role="3Jn$fo">
-              <node concept="3clFbS" id="44Cv2OMCjL7" role="2VODD2">
-                <node concept="3clFbF" id="44Cv2OMCjNR" role="3cqZAp">
-                  <node concept="2OqwBi" id="44Cv2OMCk10" role="3clFbG">
-                    <node concept="30H73N" id="44Cv2OMCjNQ" role="2Oq$k0" />
-                    <node concept="3Tsc0h" id="44Cv2OMCkfS" role="2OqNvi">
+            <node concept="3JmXsc" id="7akAd_T$Me0" role="3Jn$fo">
+              <node concept="3clFbS" id="7akAd_T$Me1" role="2VODD2">
+                <node concept="3clFbF" id="7akAd_T$Me7" role="3cqZAp">
+                  <node concept="2OqwBi" id="7akAd_T$Me2" role="3clFbG">
+                    <node concept="3Tsc0h" id="7akAd_T_6Fp" role="2OqNvi">
                       <ref role="3TtcxE" to="yvgz:3eP8Zudp5G8" resolve="data_ports" />
                     </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="17Uvod" id="44Cv2OMCksr" role="lGtFl">
-            <property role="2qtEX9" value="name" />
-            <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
-            <node concept="3zFVjK" id="44Cv2OMCkss" role="3zH0cK">
-              <node concept="3clFbS" id="44Cv2OMCkst" role="2VODD2">
-                <node concept="3cpWs8" id="44Cv2OMCky6" role="3cqZAp">
-                  <node concept="3cpWsn" id="44Cv2OMCky9" role="3cpWs9">
-                    <property role="TrG5h" value="paramString" />
-                    <node concept="17QB3L" id="44Cv2OMCky5" role="1tU5fm" />
-                    <node concept="Xl_RD" id="44Cv2OMCk$2" role="33vP2m">
-                      <property role="Xl_RC" value="" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbJ" id="44Cv2OMCkDZ" role="3cqZAp">
-                  <node concept="3clFbS" id="44Cv2OMCkE1" role="3clFbx">
-                    <node concept="3clFbF" id="44Cv2OMCmj$" role="3cqZAp">
-                      <node concept="d57v9" id="44Cv2OMCmEm" role="3clFbG">
-                        <node concept="Xl_RD" id="44Cv2OMCmKz" role="37vLTx">
-                          <property role="Xl_RC" value=", " />
-                        </node>
-                        <node concept="37vLTw" id="44Cv2OMCmjy" role="37vLTJ">
-                          <ref role="3cqZAo" node="44Cv2OMCky9" resolve="paramString" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3eOSWO" id="44Cv2OMCmci" role="3clFbw">
-                    <node concept="3cmrfG" id="44Cv2OMCmdl" role="3uHU7w">
-                      <property role="3cmrfH" value="0" />
-                    </node>
-                    <node concept="2OqwBi" id="44Cv2OMCl8A" role="3uHU7B">
-                      <node concept="1iwH7S" id="44Cv2OMCkEP" role="2Oq$k0" />
-                      <node concept="1qCSth" id="44Cv2OMClmx" role="2OqNvi">
-                        <property role="1qCSqd" value="portIndex" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3cpWs8" id="44Cv2OMCq4w" role="3cqZAp">
-                  <node concept="3cpWsn" id="44Cv2OMCq4z" role="3cpWs9">
-                    <property role="TrG5h" value="connectedPort" />
-                    <node concept="3Tqbb2" id="44Cv2OMCq4u" role="1tU5fm">
-                      <ref role="ehGHo" to="yvgz:6po$YwiVCCi" resolve="DataPort" />
-                    </node>
-                    <node concept="2OqwBi" id="44Cv2OMCqUD" role="33vP2m">
-                      <node concept="30H73N" id="44Cv2OMCqxB" role="2Oq$k0" />
-                      <node concept="2qgKlT" id="44Cv2OMCruC" role="2OqNvi">
-                        <ref role="37wK5l" to="ixp9:2FsRs4zDsXN" resolve="getPortRecursive" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbJ" id="44Cv2OMCrOK" role="3cqZAp">
-                  <node concept="3clFbS" id="44Cv2OMCrOM" role="3clFbx">
-                    <node concept="3clFbH" id="44Cv2OMCrOL" role="3cqZAp" />
-                  </node>
-                  <node concept="2OqwBi" id="44Cv2OMCsVu" role="3clFbw">
-                    <node concept="2OqwBi" id="44Cv2OMCsi5" role="2Oq$k0">
-                      <node concept="37vLTw" id="44Cv2OMCrRy" role="2Oq$k0">
-                        <ref role="3cqZAo" node="44Cv2OMCq4z" resolve="connectedPort" />
-                      </node>
-                      <node concept="3TrcHB" id="44Cv2OMCsAf" role="2OqNvi">
-                        <ref role="3TsBF5" to="yvgz:6po$YwiVCCu" resolve="direction" />
-                      </node>
-                    </node>
-                    <node concept="21noJN" id="44Cv2OMCt4H" role="2OqNvi">
-                      <node concept="21nZrQ" id="44Cv2OMCJMq" role="21noJM">
-                        <ref role="21nZrZ" to="yvgz:6po$YwiVCCm" resolve="In" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbF" id="44Cv2OMCnP6" role="3cqZAp">
-                  <node concept="d57v9" id="44Cv2OMCoEs" role="3clFbG">
-                    <node concept="37vLTw" id="44Cv2OMCoXR" role="37vLTJ">
-                      <ref role="3cqZAo" node="44Cv2OMCky9" resolve="paramString" />
-                    </node>
-                    <node concept="2OqwBi" id="44Cv2OMCo8g" role="37vLTx">
-                      <node concept="2qgKlT" id="44Cv2OMCor8" role="2OqNvi">
-                        <ref role="37wK5l" to="ixp9:7VOfr8WpcKN" resolve="getVariableName" />
-                      </node>
-                      <node concept="37vLTw" id="44Cv2OMCrFJ" role="2Oq$k0">
-                        <ref role="3cqZAo" node="44Cv2OMCq4z" resolve="connectedPort" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbF" id="44Cv2OMCkDa" role="3cqZAp">
-                  <node concept="37vLTw" id="44Cv2OMCkD8" role="3clFbG">
-                    <ref role="3cqZAo" node="44Cv2OMCky9" resolve="paramString" />
+                    <node concept="30H73N" id="7akAd_T$Me6" role="2Oq$k0" />
                   </node>
                 </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="356sEF" id="1SzGUGPGMo" role="356sEH">
+        <node concept="356sEF" id="7akAd_T$M4J" role="356sEH">
           <property role="TrG5h" value=")" />
         </node>
-        <node concept="2EixSi" id="1SzGUGPGMh" role="2EinRH" />
+        <node concept="2EixSi" id="7akAd_T$M4t" role="2EinRH" />
       </node>
-      <node concept="raruj" id="5Tr1VsJNE2N" role="lGtFl" />
+      <node concept="raruj" id="7akAd_T$M4o" role="lGtFl" />
     </node>
   </node>
   <node concept="356sEV" id="44Cv2OMJcBn">
@@ -1230,7 +1203,7 @@
           </node>
         </node>
         <node concept="5jKBG" id="44Cv2OMKz_0" role="lGtFl">
-          <ref role="v9R2y" node="44Cv2OMKz$s" resolve="include_DataBlockContainerDef" />
+          <ref role="v9R2y" node="44Cv2OMKz$s" resolve="include_DataBlockContainerDeclare" />
         </node>
       </node>
       <node concept="356sEK" id="44Cv2OMJas1" role="383Ya9">
@@ -1264,7 +1237,7 @@
     </node>
   </node>
   <node concept="13MO4I" id="44Cv2OMKz$s">
-    <property role="TrG5h" value="include_DataBlockContainerDef" />
+    <property role="TrG5h" value="include_DataBlockContainerDeclare" />
     <ref role="3gUMe" to="yvgz:5o1iPWxUm1h" resolve="DataBlockContainer" />
     <node concept="356WMU" id="44Cv2OMKz$u" role="13RCb5">
       <node concept="356sEK" id="44Cv2OMLxme" role="383Ya9">
@@ -1303,119 +1276,9 @@
         <node concept="356sEK" id="44Cv2OMLy51" role="383Ya9">
           <node concept="356sEF" id="44Cv2OMLy52" role="356sEH">
             <property role="TrG5h" value="type name" />
-            <node concept="17Uvod" id="44Cv2OMMpPW" role="lGtFl">
-              <property role="2qtEX9" value="name" />
-              <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
-              <node concept="3zFVjK" id="44Cv2OMMpPX" role="3zH0cK">
-                <node concept="3clFbS" id="44Cv2OMMpPY" role="2VODD2">
-                  <node concept="3clFbJ" id="44Cv2OMMpU$" role="3cqZAp">
-                    <node concept="2OqwBi" id="44Cv2OMMqer" role="3clFbw">
-                      <node concept="30H73N" id="44Cv2OMMpZi" role="2Oq$k0" />
-                      <node concept="1mIQ4w" id="44Cv2OMMqJm" role="2OqNvi">
-                        <node concept="chp4Y" id="44Cv2OMMqML" role="cj9EA">
-                          <ref role="cht4Q" to="yvgz:5o1iPWxUm1h" resolve="DataBlockContainer" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbS" id="44Cv2OMMpUA" role="3clFbx">
-                      <node concept="3cpWs6" id="44Cv2OMMqR2" role="3cqZAp">
-                        <node concept="3cpWs3" id="44Cv2OMMrWE" role="3cqZAk">
-                          <node concept="2OqwBi" id="44Cv2OMMsga" role="3uHU7w">
-                            <node concept="30H73N" id="44Cv2OMMrZ_" role="2Oq$k0" />
-                            <node concept="3TrcHB" id="44Cv2OMMsEl" role="2OqNvi">
-                              <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                            </node>
-                          </node>
-                          <node concept="3cpWs3" id="44Cv2OMMr_w" role="3uHU7B">
-                            <node concept="2OqwBi" id="44Cv2OMMr3T" role="3uHU7B">
-                              <node concept="30H73N" id="44Cv2OMMqSv" role="2Oq$k0" />
-                              <node concept="3TrcHB" id="44Cv2OMMr7G" role="2OqNvi">
-                                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                              </node>
-                            </node>
-                            <node concept="Xl_RD" id="44Cv2OMMrLw" role="3uHU7w">
-                              <property role="Xl_RC" value="_t " />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3cpWs8" id="5QQcZL$FQE8" role="3cqZAp">
-                    <node concept="3cpWsn" id="5QQcZL$FQEb" role="3cpWs9">
-                      <property role="TrG5h" value="memberStr" />
-                      <node concept="17QB3L" id="5QQcZL$FQE6" role="1tU5fm" />
-                      <node concept="Xl_RD" id="5QQcZL$FRhA" role="33vP2m">
-                        <property role="Xl_RC" value="" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbF" id="5QQcZL$FL55" role="3cqZAp">
-                    <node concept="2OqwBi" id="5QQcZL$FNGV" role="3clFbG">
-                      <node concept="2OqwBi" id="5QQcZL$FLu2" role="2Oq$k0">
-                        <node concept="30H73N" id="5QQcZL$FL53" role="2Oq$k0" />
-                        <node concept="3Tsc0h" id="5QQcZL$FLO8" role="2OqNvi">
-                          <ref role="3TtcxE" to="yvgz:6jvQBgXExiw" resolve="ports" />
-                        </node>
-                      </node>
-                      <node concept="2es0OD" id="5QQcZL$FPT2" role="2OqNvi">
-                        <node concept="1bVj0M" id="5QQcZL$FPT4" role="23t8la">
-                          <node concept="3clFbS" id="5QQcZL$FPT5" role="1bW5cS">
-                            <node concept="3clFbF" id="5QQcZL$FRAx" role="3cqZAp">
-                              <node concept="d57v9" id="5QQcZL$FSgN" role="3clFbG">
-                                <node concept="3cpWs3" id="5QQcZL$FWMx" role="37vLTx">
-                                  <node concept="Xl_RD" id="5QQcZL$FWT8" role="3uHU7w">
-                                    <property role="Xl_RC" value="; " />
-                                  </node>
-                                  <node concept="3cpWs3" id="5QQcZL$FUiN" role="3uHU7B">
-                                    <node concept="3cpWs3" id="5QQcZL$FTDA" role="3uHU7B">
-                                      <node concept="2OqwBi" id="5QQcZL$FSM_" role="3uHU7B">
-                                        <node concept="37vLTw" id="5QQcZL$FSur" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="5QQcZL$FPT6" resolve="dataPort" />
-                                        </node>
-                                        <node concept="3TrEf2" id="5QQcZL$FT48" role="2OqNvi">
-                                          <ref role="3Tt5mk" to="yvgz:6po$YwiVDtx" resolve="type" />
-                                        </node>
-                                      </node>
-                                      <node concept="Xl_RD" id="5QQcZL$FTJx" role="3uHU7w">
-                                        <property role="Xl_RC" value=" " />
-                                      </node>
-                                    </node>
-                                    <node concept="2OqwBi" id="5QQcZL$FVKk" role="3uHU7w">
-                                      <node concept="37vLTw" id="5QQcZL$FVx9" role="2Oq$k0">
-                                        <ref role="3cqZAo" node="5QQcZL$FPT6" resolve="dataPort" />
-                                      </node>
-                                      <node concept="2qgKlT" id="5QQcZL$FW2c" role="2OqNvi">
-                                        <ref role="37wK5l" to="ixp9:7VOfr8WpcKN" resolve="getVariableName" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                                <node concept="37vLTw" id="5QQcZL$FRAw" role="37vLTJ">
-                                  <ref role="3cqZAo" node="5QQcZL$FQEb" resolve="memberStr" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="Rh6nW" id="5QQcZL$FPT6" role="1bW2Oz">
-                            <property role="TrG5h" value="dataPort" />
-                            <node concept="2jxLKc" id="5QQcZL$FPT7" role="1tU5fm" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbF" id="44Cv2OMMsSv" role="3cqZAp">
-                    <node concept="37vLTw" id="5QQcZL$FRv1" role="3clFbG">
-                      <ref role="3cqZAo" node="5QQcZL$FQEb" resolve="memberStr" />
-                    </node>
-                  </node>
-                </node>
-              </node>
+            <node concept="1sPUBX" id="5bwHbMc8fnh" role="lGtFl">
+              <ref role="v9R2y" node="5QQcZL$HVDQ" resolve="switch_DataBlockVarDeclare" />
             </node>
-          </node>
-          <node concept="356sEF" id="44Cv2OMLyf3" role="356sEH">
-            <property role="TrG5h" value=";" />
           </node>
           <node concept="2EixSi" id="44Cv2OMLy53" role="2EinRH" />
           <node concept="1WS0z7" id="44Cv2OMLyf8" role="lGtFl">
@@ -1722,11 +1585,8 @@
             <node concept="3NFfHV" id="58QN4$b37nP" role="5jGum">
               <node concept="3clFbS" id="58QN4$b37nQ" role="2VODD2">
                 <node concept="3clFbF" id="58QN4$b37pM" role="3cqZAp">
-                  <node concept="2OqwBi" id="58QN4$b37zN" role="3clFbG">
-                    <node concept="1iwH7S" id="58QN4$b37pL" role="2Oq$k0" />
-                    <node concept="3cR$yn" id="58QN4$b37BI" role="2OqNvi">
-                      <ref role="3cRzXn" node="58QN4$b2Mji" resolve="parentFunction" />
-                    </node>
+                  <node concept="v3LJS" id="7akAd_T$jMK" role="3clFbG">
+                    <ref role="v3LJV" node="58QN4$b2Mji" resolve="parentFunction" />
                   </node>
                 </node>
               </node>
@@ -1757,14 +1617,11 @@
                 <node concept="3clFbS" id="58QN4$b5ahz" role="2VODD2">
                   <node concept="3clFbF" id="58QN4$b5akj" role="3cqZAp">
                     <node concept="2OqwBi" id="58QN4$b5aPU" role="3clFbG">
-                      <node concept="2OqwBi" id="58QN4$b5awz" role="2Oq$k0">
-                        <node concept="1iwH7S" id="58QN4$b5aki" role="2Oq$k0" />
-                        <node concept="3cR$yn" id="58QN4$b5aAP" role="2OqNvi">
-                          <ref role="3cRzXn" node="58QN4$b2Mji" resolve="parentFunction" />
-                        </node>
-                      </node>
                       <node concept="3Tsc0h" id="58QN4$b5b3k" role="2OqNvi">
                         <ref role="3TtcxE" to="yvgz:4iWYoaWUTsk" resolve="data_blocks" />
+                      </node>
+                      <node concept="v3LJS" id="5bwHbMc6mp5" role="2Oq$k0">
+                        <ref role="v3LJV" node="58QN4$b2Mji" resolve="parentFunction" />
                       </node>
                     </node>
                   </node>
@@ -1800,6 +1657,361 @@
         <node concept="2EixSi" id="58QN4$b2$n_" role="2EinRH" />
       </node>
       <node concept="raruj" id="58QN4$b2$i2" role="lGtFl" />
+    </node>
+  </node>
+  <node concept="13MO4I" id="7akAd_T$TvZ">
+    <property role="TrG5h" value="include_ResolveDataConnection" />
+    <ref role="3gUMe" to="yvgz:6po$YwiVCCi" resolve="DataPort" />
+    <node concept="1N15co" id="7akAd_T$Twc" role="1s_3oS">
+      <property role="TrG5h" value="parentFunction" />
+      <node concept="3Tqbb2" id="7akAd_T$Two" role="1N15GL">
+        <ref role="ehGHo" to="yvgz:3eP8Zudp5G4" resolve="FunctionBlock" />
+      </node>
+    </node>
+    <node concept="1N15co" id="7akAd_T$Tww" role="1s_3oS">
+      <property role="TrG5h" value="parentContainer" />
+      <node concept="3Tqbb2" id="7akAd_T$TwM" role="1N15GL">
+        <ref role="ehGHo" to="yvgz:7YUYw4xHlaz" resolve="FunctionBlockContainer" />
+      </node>
+    </node>
+    <node concept="1N15co" id="7akAd_TApba" role="1s_3oS">
+      <property role="TrG5h" value="isArgAddressType" />
+      <node concept="10P_77" id="7akAd_TApgU" role="1N15GL" />
+    </node>
+    <node concept="356WMU" id="7akAd_T$Tw1" role="13RCb5">
+      <node concept="356sEK" id="7akAd_T_dUb" role="383Ya9">
+        <node concept="356sEF" id="7akAd_T_dUc" role="356sEH">
+          <property role="TrG5h" value="argument" />
+          <node concept="17Uvod" id="7akAd_T_dUn" role="lGtFl">
+            <property role="2qtEX9" value="name" />
+            <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+            <node concept="3zFVjK" id="7akAd_T_dUo" role="3zH0cK">
+              <node concept="3clFbS" id="7akAd_T_dUp" role="2VODD2">
+                <node concept="3cpWs8" id="7akAd_T_e4G" role="3cqZAp">
+                  <node concept="3cpWsn" id="7akAd_T_e4J" role="3cpWs9">
+                    <property role="TrG5h" value="connectedPorts" />
+                    <node concept="2I9FWS" id="7akAd_T_e4E" role="1tU5fm">
+                      <ref role="2I9WkF" to="yvgz:6po$YwiVCCi" resolve="DataPort" />
+                    </node>
+                    <node concept="2OqwBi" id="7akAd_T_eob" role="33vP2m">
+                      <node concept="v3LJS" id="7akAd_T_ecC" role="2Oq$k0">
+                        <ref role="v3LJV" node="7akAd_T$Tww" resolve="parentContainer" />
+                      </node>
+                      <node concept="2qgKlT" id="7akAd_T_e$M" role="2OqNvi">
+                        <ref role="37wK5l" to="ixp9:1Fy8yZq9o69" resolve="findConnectedDataPorts" />
+                        <node concept="30H73N" id="7akAd_T_eEk" role="37wK5m" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="7akAd_T_eGz" role="3cqZAp">
+                  <node concept="3clFbS" id="7akAd_T_eG_" role="3clFbx">
+                    <node concept="3cpWs8" id="5PE55GMLRLc" role="3cqZAp">
+                      <node concept="3cpWsn" id="5PE55GMLRLf" role="3cpWs9">
+                        <property role="TrG5h" value="errString" />
+                        <node concept="17QB3L" id="5PE55GMLRLa" role="1tU5fm" />
+                        <node concept="3cpWs3" id="7akAd_T_qy_" role="33vP2m">
+                          <node concept="2OqwBi" id="7akAd_T_tdc" role="3uHU7w">
+                            <node concept="37vLTw" id="7akAd_T_qB6" role="2Oq$k0">
+                              <ref role="3cqZAo" node="7akAd_T_e4J" resolve="connectedPorts" />
+                            </node>
+                            <node concept="34oBXx" id="7akAd_T_voG" role="2OqNvi" />
+                          </node>
+                          <node concept="3cpWs3" id="7akAd_T_qd5" role="3uHU7B">
+                            <node concept="3cpWs3" id="7akAd_T_oDx" role="3uHU7B">
+                              <node concept="3cpWs3" id="7akAd_T_nj3" role="3uHU7B">
+                                <node concept="3cpWs3" id="7akAd_T_myr" role="3uHU7B">
+                                  <node concept="Xl_RD" id="5PE55GMLSlK" role="3uHU7B">
+                                    <property role="Xl_RC" value="Expected 1 data port connected to a port '" />
+                                  </node>
+                                  <node concept="2OqwBi" id="7akAd_T_mS8" role="3uHU7w">
+                                    <node concept="30H73N" id="7akAd_T_m_j" role="2Oq$k0" />
+                                    <node concept="3TrcHB" id="7akAd_T_n4J" role="2OqNvi">
+                                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="Xl_RD" id="7akAd_T_nqJ" role="3uHU7w">
+                                  <property role="Xl_RC" value="' of function '" />
+                                </node>
+                              </node>
+                              <node concept="2OqwBi" id="7akAd_T_oNh" role="3uHU7w">
+                                <node concept="v3LJS" id="7akAd_T_oHe" role="2Oq$k0">
+                                  <ref role="v3LJV" node="7akAd_T$Twc" resolve="parentFunction" />
+                                </node>
+                                <node concept="3TrcHB" id="7akAd_T_p3F" role="2OqNvi">
+                                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="Xl_RD" id="7akAd_T_qho" role="3uHU7w">
+                              <property role="Xl_RC" value="'. Found:" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2xdQw9" id="5bwHbMc6W97" role="3cqZAp">
+                      <property role="2xdLsb" value="gZ5fh_4/error" />
+                      <node concept="37vLTw" id="5bwHbMc6W99" role="9lYJi">
+                        <ref role="3cqZAo" node="5PE55GMLRLf" resolve="errString" />
+                      </node>
+                      <node concept="2ShNRf" id="5bwHbMc6W9a" role="9lYJj">
+                        <node concept="1pGfFk" id="5bwHbMc6W9b" role="2ShVmc">
+                          <ref role="37wK5l" to="wyt6:~RuntimeException.&lt;init&gt;(java.lang.String)" resolve="RuntimeException" />
+                          <node concept="37vLTw" id="5bwHbMc6W9c" role="37wK5m">
+                            <ref role="3cqZAo" node="5PE55GMLRLf" resolve="errString" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3y3z36" id="7akAd_T_kjd" role="3clFbw">
+                    <node concept="3cmrfG" id="7akAd_T_kJH" role="3uHU7w">
+                      <property role="3cmrfH" value="1" />
+                    </node>
+                    <node concept="2OqwBi" id="7akAd_T_gVS" role="3uHU7B">
+                      <node concept="37vLTw" id="7akAd_T_eI3" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7akAd_T_e4J" resolve="connectedPorts" />
+                      </node>
+                      <node concept="34oBXx" id="7akAd_T_j54" role="2OqNvi" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="7akAd_TAqhp" role="3cqZAp">
+                  <node concept="3cpWsn" id="7akAd_TAqhs" role="3cpWs9">
+                    <property role="TrG5h" value="argument" />
+                    <node concept="17QB3L" id="7akAd_TAqhn" role="1tU5fm" />
+                    <node concept="Xl_RD" id="7akAd_TAJLU" role="33vP2m">
+                      <property role="Xl_RC" value="" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="7akAd_TBsCC" role="3cqZAp">
+                  <node concept="3cpWsn" id="7akAd_TBsCF" role="3cpWs9">
+                    <property role="TrG5h" value="connectedPortParent" />
+                    <node concept="3Tqbb2" id="7akAd_TBsCA" role="1tU5fm" />
+                    <node concept="2OqwBi" id="7akAd_TBz_Y" role="33vP2m">
+                      <node concept="2OqwBi" id="7akAd_TBwiO" role="2Oq$k0">
+                        <node concept="37vLTw" id="7akAd_TBtRC" role="2Oq$k0">
+                          <ref role="3cqZAo" node="7akAd_T_e4J" resolve="connectedPorts" />
+                        </node>
+                        <node concept="1uHKPH" id="7akAd_TBy5S" role="2OqNvi" />
+                      </node>
+                      <node concept="1mfA1w" id="7akAd_TB$H2" role="2OqNvi" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="7akAd_TAtjC" role="3cqZAp">
+                  <node concept="3clFbS" id="7akAd_TAtjE" role="3clFbx">
+                    <node concept="3clFbJ" id="7akAd_TAIvS" role="3cqZAp">
+                      <node concept="3fqX7Q" id="7akAd_TAIAL" role="3clFbw">
+                        <node concept="v3LJS" id="7akAd_TAIHH" role="3fr31v">
+                          <ref role="v3LJV" node="7akAd_TApba" resolve="isArgAddressType" />
+                        </node>
+                      </node>
+                      <node concept="3clFbS" id="7akAd_TAIvU" role="3clFbx">
+                        <node concept="3clFbF" id="7akAd_TAJSJ" role="3cqZAp">
+                          <node concept="d57v9" id="7akAd_TAKtc" role="3clFbG">
+                            <node concept="Xl_RD" id="7akAd_TAK$5" role="37vLTx">
+                              <property role="Xl_RC" value="*" />
+                            </node>
+                            <node concept="37vLTw" id="7akAd_TAJSI" role="37vLTJ">
+                              <ref role="3cqZAo" node="7akAd_TAqhs" resolve="argument" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="7akAd_TALJa" role="3cqZAp">
+                      <node concept="d57v9" id="7akAd_TAM7Q" role="3clFbG">
+                        <node concept="2OqwBi" id="7akAd_TART0" role="37vLTx">
+                          <node concept="2OqwBi" id="7akAd_TAPBk" role="2Oq$k0">
+                            <node concept="37vLTw" id="7akAd_TAM$Y" role="2Oq$k0">
+                              <ref role="3cqZAo" node="7akAd_T_e4J" resolve="connectedPorts" />
+                            </node>
+                            <node concept="1uHKPH" id="7akAd_TARlP" role="2OqNvi" />
+                          </node>
+                          <node concept="3TrcHB" id="7akAd_TAT1D" role="2OqNvi">
+                            <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                          </node>
+                        </node>
+                        <node concept="37vLTw" id="7akAd_TALJ8" role="37vLTJ">
+                          <ref role="3cqZAo" node="7akAd_TAqhs" resolve="argument" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="7akAd_TA$e4" role="3clFbw">
+                    <node concept="37vLTw" id="7akAd_TB_e6" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7akAd_TBsCF" resolve="connectedPortParent" />
+                    </node>
+                    <node concept="1mIQ4w" id="7akAd_TA_dp" role="2OqNvi">
+                      <node concept="chp4Y" id="7akAd_TA_k4" role="cj9EA">
+                        <ref role="cht4Q" to="yvgz:3eP8Zudp5G4" resolve="FunctionBlock" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3eNFk2" id="7akAd_TATMk" role="3eNLev">
+                    <node concept="2OqwBi" id="7akAd_TBrX4" role="3eO9$A">
+                      <node concept="37vLTw" id="7akAd_TBAnv" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7akAd_TBsCF" resolve="connectedPortParent" />
+                      </node>
+                      <node concept="1mIQ4w" id="7akAd_TBsel" role="2OqNvi">
+                        <node concept="chp4Y" id="7akAd_TBACK" role="cj9EA">
+                          <ref role="cht4Q" to="yvgz:29RmJoXeePk" resolve="DataBlock" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbS" id="7akAd_TATMm" role="3eOfB_">
+                      <node concept="3clFbJ" id="7akAd_TBBpD" role="3cqZAp">
+                        <node concept="v3LJS" id="7akAd_TBBzz" role="3clFbw">
+                          <ref role="v3LJV" node="7akAd_TApba" resolve="isArgAddressType" />
+                        </node>
+                        <node concept="3clFbS" id="7akAd_TBBpF" role="3clFbx">
+                          <node concept="3clFbF" id="7akAd_TBC_i" role="3cqZAp">
+                            <node concept="d57v9" id="7akAd_TBDgb" role="3clFbG">
+                              <node concept="Xl_RD" id="7akAd_TBDq5" role="37vLTx">
+                                <property role="Xl_RC" value="&amp;" />
+                              </node>
+                              <node concept="37vLTw" id="7akAd_TBC_h" role="37vLTJ">
+                                <ref role="3cqZAo" node="7akAd_TAqhs" resolve="argument" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3cpWs8" id="5PE55GMNHrM" role="3cqZAp">
+                        <node concept="3cpWsn" id="5PE55GMNHrN" role="3cpWs9">
+                          <property role="TrG5h" value="connectedData" />
+                          <node concept="3Tqbb2" id="5PE55GMNHrO" role="1tU5fm">
+                            <ref role="ehGHo" to="yvgz:29RmJoXeePk" resolve="DataBlock" />
+                          </node>
+                          <node concept="1PxgMI" id="5PE55GMNHrP" role="33vP2m">
+                            <property role="1BlNFB" value="true" />
+                            <node concept="chp4Y" id="5PE55GMNHrQ" role="3oSUPX">
+                              <ref role="cht4Q" to="yvgz:29RmJoXeePk" resolve="DataBlock" />
+                            </node>
+                            <node concept="37vLTw" id="7akAd_TBJDI" role="1m5AlR">
+                              <ref role="3cqZAo" node="7akAd_TBsCF" resolve="connectedPortParent" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="7akAd_TBKk$" role="3cqZAp">
+                        <node concept="d57v9" id="7akAd_TBMi5" role="3clFbG">
+                          <node concept="37vLTw" id="7akAd_TBNnn" role="37vLTJ">
+                            <ref role="3cqZAo" node="7akAd_TAqhs" resolve="argument" />
+                          </node>
+                          <node concept="3cpWs3" id="1SzGUGQ5ux" role="37vLTx">
+                            <node concept="3cpWs3" id="1SzGUGQ4Cp" role="3uHU7B">
+                              <node concept="2OqwBi" id="7VOfr8WpdHp" role="3uHU7B">
+                                <node concept="37vLTw" id="7VOfr8Wpdvw" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="5PE55GMNHrN" resolve="connectedData" />
+                                </node>
+                                <node concept="3TrcHB" id="7VOfr8WpdQ6" role="2OqNvi">
+                                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                                </node>
+                              </node>
+                              <node concept="Xl_RD" id="1SzGUGQ4LF" role="3uHU7w">
+                                <property role="Xl_RC" value="_" />
+                              </node>
+                            </node>
+                            <node concept="2OqwBi" id="5bwHbMc6AWS" role="3uHU7w">
+                              <node concept="2OqwBi" id="5bwHbMc6z0n" role="2Oq$k0">
+                                <node concept="37vLTw" id="5bwHbMc6wAv" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="7akAd_T_e4J" resolve="connectedPorts" />
+                                </node>
+                                <node concept="1uHKPH" id="5bwHbMc6Aao" role="2OqNvi" />
+                              </node>
+                              <node concept="3TrcHB" id="5bwHbMc6Bkm" role="2OqNvi">
+                                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="9aQIb" id="7akAd_TAtww" role="9aQIa">
+                    <node concept="3clFbS" id="7akAd_TAtwx" role="9aQI4">
+                      <node concept="3cpWs8" id="7akAd_TATTN" role="3cqZAp">
+                        <node concept="3cpWsn" id="7akAd_TATTQ" role="3cpWs9">
+                          <property role="TrG5h" value="errString" />
+                          <node concept="17QB3L" id="7akAd_TATTM" role="1tU5fm" />
+                          <node concept="3cpWs3" id="7akAd_TBbo5" role="33vP2m">
+                            <node concept="2OqwBi" id="7akAd_TBhdp" role="3uHU7w">
+                              <node concept="37vLTw" id="7akAd_TBBfQ" role="2Oq$k0">
+                                <ref role="3cqZAo" node="7akAd_TBsCF" resolve="connectedPortParent" />
+                              </node>
+                              <node concept="2yIwOk" id="7akAd_TBhsV" role="2OqNvi" />
+                            </node>
+                            <node concept="3cpWs3" id="7akAd_TB9q_" role="3uHU7B">
+                              <node concept="3cpWs3" id="7akAd_TB8Bv" role="3uHU7B">
+                                <node concept="3cpWs3" id="7akAd_TB3xN" role="3uHU7B">
+                                  <node concept="3cpWs3" id="7akAd_TAXwJ" role="3uHU7B">
+                                    <node concept="Xl_RD" id="7akAd_TAVn6" role="3uHU7B">
+                                      <property role="Xl_RC" value="unexpected parent concept for port '" />
+                                    </node>
+                                    <node concept="2OqwBi" id="7akAd_TB2AJ" role="3uHU7w">
+                                      <node concept="2OqwBi" id="7akAd_TB0lR" role="2Oq$k0">
+                                        <node concept="37vLTw" id="7akAd_TAXBM" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="7akAd_T_e4J" resolve="connectedPorts" />
+                                        </node>
+                                        <node concept="1uHKPH" id="7akAd_TB24y" role="2OqNvi" />
+                                      </node>
+                                      <node concept="3TrcHB" id="7akAd_TB30T" role="2OqNvi">
+                                        <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="Xl_RD" id="7akAd_TB4v1" role="3uHU7w">
+                                    <property role="Xl_RC" value="' (connected to port '" />
+                                  </node>
+                                </node>
+                                <node concept="2OqwBi" id="7akAd_TB93L" role="3uHU7w">
+                                  <node concept="30H73N" id="7akAd_TB8Kl" role="2Oq$k0" />
+                                  <node concept="3TrcHB" id="7akAd_TB9hH" role="2OqNvi">
+                                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="Xl_RD" id="7akAd_TB9$0" role="3uHU7w">
+                                <property role="Xl_RC" value="'):" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2xdQw9" id="5bwHbMc6TUa" role="3cqZAp">
+                        <property role="2xdLsb" value="gZ5fh_4/error" />
+                        <node concept="37vLTw" id="5bwHbMc6TUc" role="9lYJi">
+                          <ref role="3cqZAo" node="7akAd_TATTQ" resolve="errString" />
+                        </node>
+                        <node concept="2ShNRf" id="5bwHbMc6TUd" role="9lYJj">
+                          <node concept="1pGfFk" id="5bwHbMc6TUe" role="2ShVmc">
+                            <ref role="37wK5l" to="wyt6:~RuntimeException.&lt;init&gt;(java.lang.String)" resolve="RuntimeException" />
+                            <node concept="37vLTw" id="5bwHbMc6TUf" role="37wK5m">
+                              <ref role="3cqZAo" node="7akAd_TATTQ" resolve="errString" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="7akAd_TATqt" role="3cqZAp">
+                  <node concept="37vLTw" id="7akAd_TATqr" role="3clFbG">
+                    <ref role="3cqZAo" node="7akAd_TAqhs" resolve="argument" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2EixSi" id="7akAd_T_dUd" role="2EinRH" />
+      </node>
+      <node concept="raruj" id="7akAd_T$Tw9" role="lGtFl" />
     </node>
   </node>
 </model>

--- a/languages/Algorithm_CGenerator/generator/templates/main@generator.mps
+++ b/languages/Algorithm_CGenerator/generator/templates/main@generator.mps
@@ -101,6 +101,9 @@
         <reference id="1168619429071" name="applicableConcept" index="n9lRv" />
       </concept>
       <concept id="1095672379244" name="jetbrains.mps.lang.generator.structure.TemplateFragment" flags="ng" index="raruj" />
+      <concept id="5005282049925926521" name="jetbrains.mps.lang.generator.structure.TemplateArgumentParameterExpression" flags="nn" index="v3LJS">
+        <reference id="5005282049925926522" name="parameter" index="v3LJV" />
+      </concept>
       <concept id="1722980698497626400" name="jetbrains.mps.lang.generator.structure.ITemplateCall" flags="ng" index="v9R3L">
         <reference id="1722980698497626483" name="template" index="v9R2y" />
         <child id="1722980698497626405" name="actualArgument" index="v9R3O" />
@@ -363,14 +366,14 @@
         </node>
         <node concept="5jKBG" id="58QN4$b2BYk" role="lGtFl">
           <ref role="v9R2y" node="58QN4$b2$hR" resolve="include_SchedulerBlock" />
-          <node concept="1PxgMI" id="58QN4$b2OhQ" role="v9R3O">
+          <node concept="1PxgMI" id="7akAd_TxkMF" role="v9R3O">
             <property role="1BlNFB" value="true" />
-            <node concept="chp4Y" id="58QN4$b2Oja" role="3oSUPX">
+            <node concept="chp4Y" id="7akAd_TxkO7" role="3oSUPX">
               <ref role="cht4Q" to="yvgz:7YUYw4xHlaz" resolve="FunctionBlockContainer" />
             </node>
             <node concept="2OqwBi" id="58QN4$b2NX1" role="1m5AlR">
               <node concept="30H73N" id="58QN4$b2Ntr" role="2Oq$k0" />
-              <node concept="1mfA1w" id="58QN4$b2Oax" role="2OqNvi" />
+              <node concept="1mfA1w" id="7akAd_TxkFq" role="2OqNvi" />
             </node>
           </node>
         </node>
@@ -449,6 +452,12 @@
   <node concept="13MO4I" id="5Tr1VsJDHgU">
     <property role="TrG5h" value="reduce_FixedDataFlowSchedulerBlock" />
     <ref role="3gUMe" to="yvgz:3EtQu_veq2" resolve="FixedDataFlowSchedulerBlock" />
+    <node concept="1N15co" id="58QN4$b5Z0w" role="1s_3oS">
+      <property role="TrG5h" value="parentFunction" />
+      <node concept="3Tqbb2" id="58QN4$b6055" role="1N15GL">
+        <ref role="ehGHo" to="yvgz:7YUYw4xHlaz" resolve="FunctionBlockContainer" />
+      </node>
+    </node>
     <node concept="356WMU" id="5Tr1VsJDHh3" role="13RCb5">
       <node concept="356sEK" id="5Tr1VsJDHhb" role="383Ya9">
         <node concept="356sEF" id="5Tr1VsJDHhc" role="356sEH">
@@ -461,6 +470,9 @@
           <property role="TrG5h" value="functionCall()" />
           <node concept="1sPUBX" id="5Tr1VsJKrD4" role="lGtFl">
             <ref role="v9R2y" node="5Tr1VsJKqPj" resolve="switch_FunctionCall" />
+            <node concept="v3LJS" id="7akAd_TzHrh" role="v9R3O">
+              <ref role="v3LJV" node="58QN4$b5Z0w" resolve="parentFunction" />
+            </node>
           </node>
         </node>
         <node concept="356sEF" id="5Tr1VsJDHZu" role="356sEH">
@@ -470,24 +482,6 @@
         <node concept="1WS0z7" id="5Tr1VsJDHZz" role="lGtFl">
           <node concept="3JmXsc" id="5Tr1VsJDHZ$" role="3Jn$fo">
             <node concept="3clFbS" id="5Tr1VsJDHZ_" role="2VODD2">
-              <node concept="3cpWs8" id="5Tr1VsJDK5j" role="3cqZAp">
-                <node concept="3cpWsn" id="5Tr1VsJDK5m" role="3cpWs9">
-                  <property role="TrG5h" value="parent" />
-                  <node concept="3Tqbb2" id="5Tr1VsJDK5h" role="1tU5fm">
-                    <ref role="ehGHo" to="yvgz:7YUYw4xHlaz" resolve="FunctionBlockContainer" />
-                  </node>
-                  <node concept="1PxgMI" id="5Tr1VsJDKPh" role="33vP2m">
-                    <property role="1BlNFB" value="true" />
-                    <node concept="chp4Y" id="5Tr1VsJDKWl" role="3oSUPX">
-                      <ref role="cht4Q" to="yvgz:7YUYw4xHlaz" resolve="FunctionBlockContainer" />
-                    </node>
-                    <node concept="2OqwBi" id="5Tr1VsJDKuo" role="1m5AlR">
-                      <node concept="30H73N" id="5Tr1VsJDKfe" role="2Oq$k0" />
-                      <node concept="1mfA1w" id="5Tr1VsJDKEq" role="2OqNvi" />
-                    </node>
-                  </node>
-                </node>
-              </node>
               <node concept="3cpWs8" id="5Tr1VsJDLlo" role="3cqZAp">
                 <node concept="3cpWsn" id="5Tr1VsJDLlr" role="3cpWs9">
                   <property role="TrG5h" value="functions" />
@@ -518,8 +512,11 @@
                           <node concept="3cpWsn" id="5Tr1VsJDTLk" role="3cpWs9">
                             <property role="TrG5h" value="connectedPorts" />
                             <node concept="2OqwBi" id="5Tr1VsJDQx6" role="33vP2m">
-                              <node concept="37vLTw" id="5Tr1VsJDQfJ" role="2Oq$k0">
-                                <ref role="3cqZAo" node="5Tr1VsJDK5m" resolve="parent" />
+                              <node concept="2OqwBi" id="58QN4$b61TJ" role="2Oq$k0">
+                                <node concept="1iwH7S" id="58QN4$b61rV" role="2Oq$k0" />
+                                <node concept="3cR$yn" id="58QN4$b62dg" role="2OqNvi">
+                                  <ref role="3cRzXn" node="58QN4$b5Z0w" resolve="parentFunction" />
+                                </node>
                               </node>
                               <node concept="2qgKlT" id="5Tr1VsJDQP4" role="2OqNvi">
                                 <ref role="37wK5l" to="ixp9:2RC7aVK84L5" resolve="findConnectedTriggerPorts" />
@@ -663,11 +660,11 @@
                               </node>
                             </node>
                           </node>
-                          <node concept="2OqwBi" id="5Tr1VsJHP6s" role="3clFbw">
-                            <node concept="37vLTw" id="5Tr1VsJHNRi" role="2Oq$k0">
+                          <node concept="2OqwBi" id="7akAd_TzFNJ" role="3clFbw">
+                            <node concept="37vLTw" id="7akAd_TzFpo" role="2Oq$k0">
                               <ref role="3cqZAo" node="5Tr1VsJHEkp" resolve="connectedParent" />
                             </node>
-                            <node concept="3w_OXm" id="5Tr1VsJHPz6" role="2OqNvi" />
+                            <node concept="3w_OXm" id="7akAd_TzH0U" role="2OqNvi" />
                           </node>
                         </node>
                         <node concept="3clFbF" id="5Tr1VsJEbN4" role="3cqZAp">
@@ -709,6 +706,12 @@
   <node concept="13MO4I" id="5Tr1VsJEoGm">
     <property role="TrG5h" value="reduce_EmptyFunctionCall" />
     <ref role="3gUMe" to="yvgz:29RmJoXeePh" resolve="EmptyFunctionBlock" />
+    <node concept="1N15co" id="58QN4$b6aGm" role="1s_3oS">
+      <property role="TrG5h" value="parentFunction" />
+      <node concept="3Tqbb2" id="58QN4$b6aNp" role="1N15GL">
+        <ref role="ehGHo" to="yvgz:7YUYw4xHlaz" resolve="FunctionBlockContainer" />
+      </node>
+    </node>
     <node concept="356WMU" id="5Tr1VsJEoGo" role="13RCb5">
       <node concept="356sEK" id="Ho3faVHPYv" role="383Ya9">
         <node concept="2EixSi" id="Ho3faVHPYx" role="2EinRH" />
@@ -735,6 +738,9 @@
           <property role="TrG5h" value="params" />
           <node concept="5jKBG" id="1SzGUGPLmh" role="lGtFl">
             <ref role="v9R2y" node="5Tr1VsJNE2J" resolve="include_FunctionCallArgs" />
+            <node concept="v3LJS" id="7akAd_TzORj" role="v9R3O">
+              <ref role="v3LJV" node="58QN4$b6aGm" resolve="parentFunction" />
+            </node>
           </node>
         </node>
       </node>
@@ -743,6 +749,12 @@
   </node>
   <node concept="jVnub" id="5Tr1VsJJAo1">
     <property role="TrG5h" value="switch_SchedulerBlock" />
+    <node concept="1N15co" id="58QN4$b5Yt7" role="1s_3oS">
+      <property role="TrG5h" value="parentFunction" />
+      <node concept="3Tqbb2" id="58QN4$b5Ytf" role="1N15GL">
+        <ref role="ehGHo" to="yvgz:7YUYw4xHlaz" resolve="FunctionBlockContainer" />
+      </node>
+    </node>
     <node concept="3aamgX" id="5Tr1VsJJAxB" role="3aUrZf">
       <property role="36QftV" value="true" />
       <ref role="30HIoZ" to="yvgz:3EtQu_tAJA" resolve="EmptySchedulerBlock" />
@@ -765,6 +777,9 @@
       <ref role="30HIoZ" to="yvgz:3EtQu_veq2" resolve="FixedDataFlowSchedulerBlock" />
       <node concept="j$656" id="5Tr1VsJJBjt" role="1lVwrX">
         <ref role="v9R2y" node="5Tr1VsJDHgU" resolve="reduce_FixedDataFlowSchedulerBlock" />
+        <node concept="v3LJS" id="7akAd_Tzx$i" role="v9R3O">
+          <ref role="v3LJV" node="58QN4$b5Yt7" resolve="parentFunction" />
+        </node>
       </node>
     </node>
   </node>
@@ -780,11 +795,19 @@
   </node>
   <node concept="jVnub" id="5Tr1VsJKqPj">
     <property role="TrG5h" value="switch_FunctionCall" />
+    <node concept="1N15co" id="58QN4$b6aw3" role="1s_3oS">
+      <property role="TrG5h" value="parentFunction" />
+      <node concept="3Tqbb2" id="58QN4$b6awd" role="1N15GL">
+        <ref role="ehGHo" to="yvgz:7YUYw4xHlaz" resolve="FunctionBlockContainer" />
+      </node>
+    </node>
     <node concept="3aamgX" id="5Tr1VsJKqPk" role="3aUrZf">
-      <property role="36QftV" value="true" />
       <ref role="30HIoZ" to="yvgz:29RmJoXeePh" resolve="EmptyFunctionBlock" />
       <node concept="j$656" id="5Tr1VsJKqPo" role="1lVwrX">
         <ref role="v9R2y" node="5Tr1VsJEoGm" resolve="reduce_EmptyFunctionCall" />
+        <node concept="v3LJS" id="7akAd_TzHr$" role="v9R3O">
+          <ref role="v3LJV" node="58QN4$b6aw3" resolve="parentFunction" />
+        </node>
       </node>
     </node>
   </node>
@@ -935,6 +958,12 @@
   <node concept="13MO4I" id="5Tr1VsJNE2J">
     <property role="TrG5h" value="include_FunctionCallArgs" />
     <ref role="3gUMe" to="yvgz:3eP8Zudp5G4" resolve="FunctionBlock" />
+    <node concept="1N15co" id="7akAd_TzOEr" role="1s_3oS">
+      <property role="TrG5h" value="parentFunction" />
+      <node concept="3Tqbb2" id="7akAd_TzORa" role="1N15GL">
+        <ref role="ehGHo" to="yvgz:7YUYw4xHlaz" resolve="FunctionBlockContainer" />
+      </node>
+    </node>
     <node concept="356WMU" id="5Tr1VsJNE2L" role="13RCb5">
       <node concept="356sEK" id="1SzGUGPGMf" role="383Ya9">
         <node concept="356sEF" id="1SzGUGPGMg" role="356sEH">
@@ -1639,8 +1668,8 @@
     <property role="TrG5h" value="include_SchedulerBlock" />
     <ref role="3gUMe" to="yvgz:29RmJoXeePl" resolve="SchedulerBlock" />
     <node concept="1N15co" id="58QN4$b2Mji" role="1s_3oS">
-      <property role="TrG5h" value="parent" />
-      <node concept="3Tqbb2" id="58QN4$b2Mqs" role="1N15GL">
+      <property role="TrG5h" value="parentFunction" />
+      <node concept="3Tqbb2" id="7akAd_TxV8x" role="1N15GL">
         <ref role="ehGHo" to="yvgz:7YUYw4xHlaz" resolve="FunctionBlockContainer" />
       </node>
     </node>
@@ -1672,7 +1701,7 @@
                         <node concept="2OqwBi" id="58QN4$b2YnE" role="2Oq$k0">
                           <node concept="1iwH7S" id="58QN4$b2Y7G" role="2Oq$k0" />
                           <node concept="3cR$yn" id="58QN4$b2Yz_" role="2OqNvi">
-                            <ref role="3cRzXn" node="58QN4$b2Mji" resolve="parent" />
+                            <ref role="3cRzXn" node="58QN4$b2Mji" resolve="parentFunction" />
                           </node>
                         </node>
                         <node concept="3TrcHB" id="58QN4$b2Jlu" role="2OqNvi">
@@ -1696,7 +1725,7 @@
                   <node concept="2OqwBi" id="58QN4$b37zN" role="3clFbG">
                     <node concept="1iwH7S" id="58QN4$b37pL" role="2Oq$k0" />
                     <node concept="3cR$yn" id="58QN4$b37BI" role="2OqNvi">
-                      <ref role="3cRzXn" node="58QN4$b2Mji" resolve="parent" />
+                      <ref role="3cRzXn" node="58QN4$b2Mji" resolve="parentFunction" />
                     </node>
                   </node>
                 </node>
@@ -1731,7 +1760,7 @@
                       <node concept="2OqwBi" id="58QN4$b5awz" role="2Oq$k0">
                         <node concept="1iwH7S" id="58QN4$b5aki" role="2Oq$k0" />
                         <node concept="3cR$yn" id="58QN4$b5aAP" role="2OqNvi">
-                          <ref role="3cRzXn" node="58QN4$b2Mji" resolve="parent" />
+                          <ref role="3cRzXn" node="58QN4$b2Mji" resolve="parentFunction" />
                         </node>
                       </node>
                       <node concept="3Tsc0h" id="58QN4$b5b3k" role="2OqNvi">
@@ -1749,12 +1778,15 @@
           <node concept="356sEK" id="58QN4$b5agg" role="383Ya9">
             <node concept="2EixSi" id="58QN4$b5agi" role="2EinRH" />
           </node>
-          <node concept="356sEK" id="58QN4$b2$o6" role="383Ya9">
-            <node concept="2EixSi" id="58QN4$b2$o8" role="2EinRH" />
-            <node concept="356sEF" id="58QN4$b2$nO" role="356sEH">
+          <node concept="356sEK" id="7akAd_Tw_8R" role="383Ya9">
+            <node concept="356sEF" id="7akAd_Tw_8S" role="356sEH">
               <property role="TrG5h" value="schedule" />
-              <node concept="1sPUBX" id="58QN4$b2$ok" role="lGtFl">
-                <ref role="v9R2y" node="5Tr1VsJJAo1" resolve="switch_SchedulerBlock" />
+            </node>
+            <node concept="2EixSi" id="7akAd_Tw_8T" role="2EinRH" />
+            <node concept="1sPUBX" id="7akAd_Tw_9B" role="lGtFl">
+              <ref role="v9R2y" node="5Tr1VsJJAo1" resolve="switch_SchedulerBlock" />
+              <node concept="v3LJS" id="7akAd_TzqbS" role="v9R3O">
+                <ref role="v3LJV" node="58QN4$b2Mji" resolve="parentFunction" />
               </node>
             </node>
           </node>

--- a/solutions/Algorithm.sandbox/models/Algorithm.sandbox.mps
+++ b/solutions/Algorithm.sandbox/models/Algorithm.sandbox.mps
@@ -146,7 +146,7 @@
       <ref role="1psEGP" node="3eP8ZudpjNK" resolve="baz-trigger" />
     </node>
     <node concept="2__D7_" id="3EtQu_vAe7" role="3SlQUj">
-      <property role="TrG5h" value="foo-sched" />
+      <property role="TrG5h" value="fooSched" />
       <node concept="1pt3V6" id="3EtQu_wAO$" role="1OHzVH">
         <property role="TrG5h" value="foo-sched-trigger" />
         <property role="2_BrWT" value="3EtQu_uj5h/In" />
@@ -313,7 +313,7 @@
       <ref role="1OHyup" node="3eP8ZudpjQd" resolve="pActuation" />
     </node>
     <node concept="2__D7_" id="3EtQu_yvp8" role="3SlQUj">
-      <property role="TrG5h" value="p-sched" />
+      <property role="TrG5h" value="pSched" />
       <node concept="1pt3V6" id="6F0tY7D9MDu" role="1OHzVH">
         <property role="TrG5h" value="p-sched-trigger" />
         <property role="2_BrWT" value="3EtQu_uj5h/In" />

--- a/solutions/Algorithm.sandbox/models/Algorithm.sandbox.mps
+++ b/solutions/Algorithm.sandbox/models/Algorithm.sandbox.mps
@@ -212,7 +212,7 @@
       <property role="1OHxBQ" value="6po$YwiVCCq/InOut" />
       <node concept="10P55v" id="3eP8ZudpjQL" role="1OHwi9" />
     </node>
-    <node concept="1OHxBB" id="3EtQu_zmNy" role="3SlQUq">
+    <node concept="1OHxBB" id="7akAd_T$g_V" role="3SlQUq">
       <ref role="1OHxBS" node="3eP8ZudpjPP" resolve="pSetpoint" />
       <ref role="1OHyup" node="3eP8ZudpjOd" resolve="setpoint" />
     </node>
@@ -251,7 +251,7 @@
       <node concept="1OHxBU" id="3EtQu_tLuD" role="1ptsVk">
         <property role="TrG5h" value="errorAccess" />
         <property role="1OHxBQ" value="6po$YwiVCCq/InOut" />
-        <node concept="10P55v" id="3EtQu_tLuH" role="1OHwi9" />
+        <node concept="10P55v" id="7akAd_T$gv$" role="1OHwi9" />
       </node>
     </node>
     <node concept="2_B1M0" id="3EtQu_tLug" role="3SlQUm">


### PR DESCRIPTION
This PR change the generator to generate a function for each `SchedulerBlock` of a `FunctionBlockContainer` (as opposed to generating one function containing all schedules for a `FunctionBlockContainer` like before).

Additionally, 387a8ea should also handle generation of `*` and `&` symbols (or lack thereof) correctly.