### PR TITLE
add constraints for DataConnector in FunctionBlockContainer

### DIFF
--- a/languages/Algorithm/models/Algorithm.behavior.mps
+++ b/languages/Algorithm/models/Algorithm.behavior.mps
@@ -51,6 +51,7 @@
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
@@ -79,6 +80,9 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
       </concept>
@@ -105,6 +109,7 @@
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
@@ -1164,6 +1169,114 @@
           </node>
         </node>
       </node>
+    </node>
+  </node>
+  <node concept="13h7C7" id="5bwHbMcf3tV">
+    <ref role="13h7C2" to="yvgz:6po$YwiVCCf" resolve="DataConnector" />
+    <node concept="13i0hz" id="5bwHbMcf3ue" role="13h7CS">
+      <property role="TrG5h" value="equals" />
+      <node concept="3Tm1VV" id="5bwHbMcf3uf" role="1B3o_S" />
+      <node concept="10P_77" id="5bwHbMcf3uD" role="3clF45" />
+      <node concept="3clFbS" id="5bwHbMcf3uh" role="3clF47">
+        <node concept="3clFbJ" id="5bwHbMcf3zH" role="3cqZAp">
+          <node concept="3clFbS" id="5bwHbMcf3zJ" role="3clFbx">
+            <node concept="3cpWs6" id="5bwHbMcf5AS" role="3cqZAp">
+              <node concept="3clFbT" id="5bwHbMcf5Be" role="3cqZAk">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+          <node concept="1Wc70l" id="5bwHbMcf4PI" role="3clFbw">
+            <node concept="3clFbC" id="5bwHbMcf54$" role="3uHU7w">
+              <node concept="2OqwBi" id="5bwHbMcf5u1" role="3uHU7w">
+                <node concept="37vLTw" id="5bwHbMcf55M" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5bwHbMcf3v5" resolve="connector" />
+                </node>
+                <node concept="3TrEf2" id="5bwHbMcf5_G" role="2OqNvi">
+                  <ref role="3Tt5mk" to="yvgz:6po$YwiVFhL" resolve="port2" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="5bwHbMcf502" role="3uHU7B">
+                <node concept="13iPFW" id="5bwHbMcf4QV" role="2Oq$k0" />
+                <node concept="3TrEf2" id="5bwHbMcf51n" role="2OqNvi">
+                  <ref role="3Tt5mk" to="yvgz:6po$YwiVFhL" resolve="port2" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbC" id="5bwHbMcf46G" role="3uHU7B">
+              <node concept="2OqwBi" id="5bwHbMcf41x" role="3uHU7B">
+                <node concept="13iPFW" id="5bwHbMcf41y" role="2Oq$k0" />
+                <node concept="3TrEf2" id="5bwHbMcf41z" role="2OqNvi">
+                  <ref role="3Tt5mk" to="yvgz:6po$YwiVCCg" resolve="port1" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="5bwHbMcf4t8" role="3uHU7w">
+                <node concept="37vLTw" id="5bwHbMcf4d7" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5bwHbMcf3v5" resolve="connector" />
+                </node>
+                <node concept="3TrEf2" id="5bwHbMcf4Gn" role="2OqNvi">
+                  <ref role="3Tt5mk" to="yvgz:6po$YwiVCCg" resolve="port1" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="5bwHbMcf5Ec" role="3cqZAp">
+          <node concept="3clFbS" id="5bwHbMcf5Ee" role="3clFbx">
+            <node concept="3cpWs6" id="5bwHbMcf7y9" role="3cqZAp">
+              <node concept="3clFbT" id="5bwHbMcf7yx" role="3cqZAk">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+          <node concept="1Wc70l" id="5bwHbMcf6L9" role="3clFbw">
+            <node concept="3clFbC" id="5bwHbMcf707" role="3uHU7w">
+              <node concept="2OqwBi" id="5bwHbMcf7pC" role="3uHU7w">
+                <node concept="37vLTw" id="5bwHbMcf71n" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5bwHbMcf3v5" resolve="connector" />
+                </node>
+                <node concept="3TrEf2" id="5bwHbMcf7wV" role="2OqNvi">
+                  <ref role="3Tt5mk" to="yvgz:6po$YwiVCCg" resolve="port1" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="5bwHbMcf6Vx" role="3uHU7B">
+                <node concept="13iPFW" id="5bwHbMcf6Mo" role="2Oq$k0" />
+                <node concept="3TrEf2" id="5bwHbMcf6WS" role="2OqNvi">
+                  <ref role="3Tt5mk" to="yvgz:6po$YwiVFhL" resolve="port2" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbC" id="5bwHbMcf68N" role="3uHU7B">
+              <node concept="2OqwBi" id="5bwHbMcf5P0" role="3uHU7B">
+                <node concept="13iPFW" id="5bwHbMcf5G2" role="2Oq$k0" />
+                <node concept="3TrEf2" id="5bwHbMcf5VY" role="2OqNvi">
+                  <ref role="3Tt5mk" to="yvgz:6po$YwiVCCg" resolve="port1" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="5bwHbMcf6ov" role="3uHU7w">
+                <node concept="37vLTw" id="5bwHbMcf6fg" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5bwHbMcf3v5" resolve="connector" />
+                </node>
+                <node concept="3TrEf2" id="5bwHbMcf6pz" role="2OqNvi">
+                  <ref role="3Tt5mk" to="yvgz:6po$YwiVFhL" resolve="port2" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5bwHbMcf3vC" role="3cqZAp">
+          <node concept="3clFbT" id="5bwHbMcf3vB" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="5bwHbMcf3v5" role="3clF46">
+        <property role="TrG5h" value="connector" />
+        <node concept="3Tqbb2" id="5bwHbMcf3v4" role="1tU5fm">
+          <ref role="ehGHo" to="yvgz:6po$YwiVCCf" resolve="DataConnector" />
+        </node>
+      </node>
+    </node>
+    <node concept="13hLZK" id="5bwHbMcf3tW" role="13h7CW">
+      <node concept="3clFbS" id="5bwHbMcf3tX" role="2VODD2" />
     </node>
   </node>
 </model>

--- a/languages/Algorithm/models/Algorithm.behavior.mps
+++ b/languages/Algorithm/models/Algorithm.behavior.mps
@@ -1279,5 +1279,113 @@
       <node concept="3clFbS" id="5bwHbMcf3tX" role="2VODD2" />
     </node>
   </node>
+  <node concept="13h7C7" id="hkK7ztNhQt">
+    <ref role="13h7C2" to="yvgz:6jvQBgXFn4Y" resolve="TriggerConnector" />
+    <node concept="13i0hz" id="hkK7ztNhQC" role="13h7CS">
+      <property role="TrG5h" value="equals" />
+      <node concept="3Tm1VV" id="hkK7ztNhQD" role="1B3o_S" />
+      <node concept="10P_77" id="hkK7ztNhQE" role="3clF45" />
+      <node concept="3clFbS" id="hkK7ztNhQF" role="3clF47">
+        <node concept="3clFbJ" id="hkK7ztNhQG" role="3cqZAp">
+          <node concept="3clFbS" id="hkK7ztNhQH" role="3clFbx">
+            <node concept="3cpWs6" id="hkK7ztNhQI" role="3cqZAp">
+              <node concept="3clFbT" id="hkK7ztNhQJ" role="3cqZAk">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+          <node concept="1Wc70l" id="hkK7ztNhQK" role="3clFbw">
+            <node concept="3clFbC" id="hkK7ztNhQL" role="3uHU7w">
+              <node concept="2OqwBi" id="hkK7ztNhQM" role="3uHU7w">
+                <node concept="37vLTw" id="hkK7ztNhQN" role="2Oq$k0">
+                  <ref role="3cqZAo" node="hkK7ztNhRk" resolve="connector" />
+                </node>
+                <node concept="3TrEf2" id="hkK7ztNivw" role="2OqNvi">
+                  <ref role="3Tt5mk" to="yvgz:6jvQBgXFn51" resolve="port2" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="hkK7ztNhQP" role="3uHU7B">
+                <node concept="13iPFW" id="hkK7ztNhQQ" role="2Oq$k0" />
+                <node concept="3TrEf2" id="hkK7ztNhQR" role="2OqNvi">
+                  <ref role="3Tt5mk" to="yvgz:6jvQBgXFn51" resolve="port2" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbC" id="hkK7ztNhQS" role="3uHU7B">
+              <node concept="2OqwBi" id="hkK7ztNhQT" role="3uHU7B">
+                <node concept="13iPFW" id="hkK7ztNhQU" role="2Oq$k0" />
+                <node concept="3TrEf2" id="hkK7ztNhQV" role="2OqNvi">
+                  <ref role="3Tt5mk" to="yvgz:6jvQBgXFn4Z" resolve="port1" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="hkK7ztNhQW" role="3uHU7w">
+                <node concept="37vLTw" id="hkK7ztNhQX" role="2Oq$k0">
+                  <ref role="3cqZAo" node="hkK7ztNhRk" resolve="connector" />
+                </node>
+                <node concept="3TrEf2" id="hkK7ztNiu1" role="2OqNvi">
+                  <ref role="3Tt5mk" to="yvgz:6jvQBgXFn4Z" resolve="port1" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="hkK7ztNhQZ" role="3cqZAp">
+          <node concept="3clFbS" id="hkK7ztNhR0" role="3clFbx">
+            <node concept="3cpWs6" id="hkK7ztNhR1" role="3cqZAp">
+              <node concept="3clFbT" id="hkK7ztNhR2" role="3cqZAk">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+          <node concept="1Wc70l" id="hkK7ztNhR3" role="3clFbw">
+            <node concept="3clFbC" id="hkK7ztNhR4" role="3uHU7w">
+              <node concept="2OqwBi" id="hkK7ztNhR5" role="3uHU7w">
+                <node concept="37vLTw" id="hkK7ztNhR6" role="2Oq$k0">
+                  <ref role="3cqZAo" node="hkK7ztNhRk" resolve="connector" />
+                </node>
+                <node concept="3TrEf2" id="hkK7ztNixi" role="2OqNvi">
+                  <ref role="3Tt5mk" to="yvgz:6jvQBgXFn4Z" resolve="port1" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="hkK7ztNhR8" role="3uHU7B">
+                <node concept="13iPFW" id="hkK7ztNhR9" role="2Oq$k0" />
+                <node concept="3TrEf2" id="hkK7ztNhRa" role="2OqNvi">
+                  <ref role="3Tt5mk" to="yvgz:6jvQBgXFn51" resolve="port2" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbC" id="hkK7ztNhRb" role="3uHU7B">
+              <node concept="2OqwBi" id="hkK7ztNhRc" role="3uHU7B">
+                <node concept="13iPFW" id="hkK7ztNhRd" role="2Oq$k0" />
+                <node concept="3TrEf2" id="hkK7ztNhRe" role="2OqNvi">
+                  <ref role="3Tt5mk" to="yvgz:6jvQBgXFn4Z" resolve="port1" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="hkK7ztNhRf" role="3uHU7w">
+                <node concept="37vLTw" id="hkK7ztNhRg" role="2Oq$k0">
+                  <ref role="3cqZAo" node="hkK7ztNhRk" resolve="connector" />
+                </node>
+                <node concept="3TrEf2" id="hkK7ztNiyL" role="2OqNvi">
+                  <ref role="3Tt5mk" to="yvgz:6jvQBgXFn51" resolve="port2" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="hkK7ztNhRi" role="3cqZAp">
+          <node concept="3clFbT" id="hkK7ztNhRj" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="hkK7ztNhRk" role="3clF46">
+        <property role="TrG5h" value="connector" />
+        <node concept="3Tqbb2" id="hkK7ztNhRl" role="1tU5fm">
+          <ref role="ehGHo" to="yvgz:6jvQBgXFn4Y" resolve="TriggerConnector" />
+        </node>
+      </node>
+    </node>
+    <node concept="13hLZK" id="hkK7ztNhQu" role="13h7CW">
+      <node concept="3clFbS" id="hkK7ztNhQv" role="2VODD2" />
+    </node>
+  </node>
 </model>
 

--- a/languages/Algorithm/models/Algorithm.constraints.mps
+++ b/languages/Algorithm/models/Algorithm.constraints.mps
@@ -18,58 +18,17 @@
     <import index="yvgz" ref="r:3b411c10-569a-4299-9505-176144359d3b(Algorithm.structure)" implicit="true" />
   </imports>
   <registry>
-    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
-      <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
-      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
-        <child id="1197027771414" name="operand" index="2Oq$k0" />
-        <child id="1197027833540" name="operation" index="2OqNvi" />
-      </concept>
-      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
-        <child id="1137022507850" name="body" index="2VODD2" />
-      </concept>
-      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
-        <child id="1068580123156" name="expression" index="3clFbG" />
-      </concept>
-      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
-        <child id="1068580123160" name="condition" index="3clFbw" />
-        <child id="1068580123161" name="ifTrue" index="3clFbx" />
-      </concept>
-      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
-        <child id="1068581517665" name="statement" index="3cqZAp" />
-      </concept>
-      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
-        <property id="1068580123138" name="value" index="3clFbU" />
-      </concept>
-      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
-        <child id="1068581517676" name="expression" index="3cqZAk" />
-      </concept>
-      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
-        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
-        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
-      </concept>
-    </language>
     <language id="3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1" name="jetbrains.mps.lang.constraints">
-      <concept id="6702802731807351367" name="jetbrains.mps.lang.constraints.structure.ConstraintFunction_CanBeAChild" flags="in" index="9S07l" />
-      <concept id="1202989658459" name="jetbrains.mps.lang.constraints.structure.ConstraintFunctionParameter_parentNode" flags="nn" index="nLn13" />
       <concept id="8401916545537438642" name="jetbrains.mps.lang.constraints.structure.InheritedNodeScopeFactory" flags="ng" index="1dDu$B">
         <reference id="8401916545537438643" name="kind" index="1dDu$A" />
       </concept>
       <concept id="1213093968558" name="jetbrains.mps.lang.constraints.structure.ConceptConstraints" flags="ng" index="1M2fIO">
         <reference id="1213093996982" name="concept" index="1M2myG" />
-        <child id="6702802731807737306" name="canBeChild" index="9Vyp8" />
         <child id="1213100494875" name="referent" index="1Mr941" />
       </concept>
       <concept id="1148687176410" name="jetbrains.mps.lang.constraints.structure.NodeReferentConstraint" flags="ng" index="1N5Pfh">
         <reference id="1148687202698" name="applicableLink" index="1N5Vy1" />
         <child id="1148687345559" name="searchScopeFactory" index="1N6uqs" />
-      </concept>
-    </language>
-    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
-        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
-      </concept>
-      <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
-        <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
     </language>
   </registry>
@@ -79,80 +38,6 @@
       <ref role="1N5Vy1" to="yvgz:3EtQu_woIa" resolve="trigger_port" />
       <node concept="1dDu$B" id="71WlwW$ynnI" role="1N6uqs">
         <ref role="1dDu$A" to="yvgz:6jvQBgXEYiM" resolve="TriggerPort" />
-      </node>
-    </node>
-  </node>
-  <node concept="1M2fIO" id="7VOfr8WpgI8">
-    <ref role="1M2myG" to="yvgz:6po$YwiVCCi" resolve="DataPort" />
-    <node concept="9S07l" id="7VOfr8Wph_V" role="9Vyp8">
-      <node concept="3clFbS" id="7VOfr8Wph_W" role="2VODD2">
-        <node concept="3clFbJ" id="7VOfr8Wpi14" role="3cqZAp">
-          <node concept="22lmx$" id="6TAIVwhB$mm" role="3clFbw">
-            <node concept="2OqwBi" id="6TAIVwhB$yx" role="3uHU7w">
-              <node concept="nLn13" id="6TAIVwhB$oM" role="2Oq$k0" />
-              <node concept="1mIQ4w" id="6TAIVwhB$T7" role="2OqNvi">
-                <node concept="chp4Y" id="6TAIVwhB_1K" role="cj9EA">
-                  <ref role="cht4Q" to="yvgz:29RmJoXeePl" resolve="SchedulerBlock" />
-                </node>
-              </node>
-            </node>
-            <node concept="22lmx$" id="7VOfr8WpiH$" role="3uHU7B">
-              <node concept="2OqwBi" id="7VOfr8Wpi8z" role="3uHU7B">
-                <node concept="nLn13" id="7VOfr8Wpi1_" role="2Oq$k0" />
-                <node concept="1mIQ4w" id="7VOfr8Wpiey" role="2OqNvi">
-                  <node concept="chp4Y" id="7VOfr8Wpin4" role="cj9EA">
-                    <ref role="cht4Q" to="yvgz:3eP8Zudp5G4" resolve="FunctionBlock" />
-                  </node>
-                </node>
-              </node>
-              <node concept="2OqwBi" id="7VOfr8WpiSg" role="3uHU7w">
-                <node concept="nLn13" id="7VOfr8WpiIY" role="2Oq$k0" />
-                <node concept="1mIQ4w" id="7VOfr8Wpj43" role="2OqNvi">
-                  <node concept="chp4Y" id="7VOfr8WpjcC" role="cj9EA">
-                    <ref role="cht4Q" to="yvgz:29RmJoXeePk" resolve="DataBlock" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbS" id="7VOfr8Wpi16" role="3clFbx">
-            <node concept="3cpWs6" id="7VOfr8Wpil$" role="3cqZAp">
-              <node concept="3clFbT" id="7VOfr8Wpimn" role="3cqZAk">
-                <property role="3clFbU" value="true" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs6" id="7VOfr8Wpihb" role="3cqZAp">
-          <node concept="3clFbT" id="7VOfr8Wpihu" role="3cqZAk" />
-        </node>
-      </node>
-    </node>
-  </node>
-  <node concept="1M2fIO" id="2RC7aVK8cUG">
-    <ref role="1M2myG" to="yvgz:6jvQBgXEYiM" resolve="TriggerPort" />
-    <node concept="9S07l" id="2RC7aVK8cUH" role="9Vyp8">
-      <node concept="3clFbS" id="2RC7aVK8cUI" role="2VODD2">
-        <node concept="3clFbF" id="2RC7aVK8cYE" role="3cqZAp">
-          <node concept="22lmx$" id="2RC7aVKa3Uk" role="3clFbG">
-            <node concept="2OqwBi" id="2RC7aVKa44H" role="3uHU7w">
-              <node concept="nLn13" id="2RC7aVKa3VD" role="2Oq$k0" />
-              <node concept="1mIQ4w" id="2RC7aVKa4qP" role="2OqNvi">
-                <node concept="chp4Y" id="2RC7aVKa4C8" role="cj9EA">
-                  <ref role="cht4Q" to="yvgz:29RmJoXeePl" resolve="SchedulerBlock" />
-                </node>
-              </node>
-            </node>
-            <node concept="2OqwBi" id="2RC7aVK8d7i" role="3uHU7B">
-              <node concept="nLn13" id="2RC7aVK8cYD" role="2Oq$k0" />
-              <node concept="1mIQ4w" id="2RC7aVK8dn$" role="2OqNvi">
-                <node concept="chp4Y" id="2RC7aVK8dx2" role="cj9EA">
-                  <ref role="cht4Q" to="yvgz:3eP8Zudp5G4" resolve="FunctionBlock" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
       </node>
     </node>
   </node>

--- a/languages/Algorithm/models/Algorithm.typesystem.mps
+++ b/languages/Algorithm/models/Algorithm.typesystem.mps
@@ -574,5 +574,141 @@
       <ref role="1YaFvo" to="yvgz:7YUYw4xHlaz" resolve="FunctionBlockContainer" />
     </node>
   </node>
+  <node concept="18kY7G" id="5bwHbMch6fJ">
+    <property role="TrG5h" value="check_DataBlockContainer" />
+    <node concept="3clFbS" id="5bwHbMch6fK" role="18ibNy">
+      <node concept="1Dw8fO" id="5bwHbMch6gh" role="3cqZAp">
+        <node concept="3cpWsn" id="5bwHbMch6gi" role="1Duv9x">
+          <property role="TrG5h" value="i" />
+          <node concept="10Oyi0" id="5bwHbMch6gj" role="1tU5fm" />
+          <node concept="3cmrfG" id="5bwHbMch6gk" role="33vP2m">
+            <property role="3cmrfH" value="0" />
+          </node>
+        </node>
+        <node concept="3clFbS" id="5bwHbMch6gl" role="2LFqv$">
+          <node concept="1Dw8fO" id="5bwHbMch6gm" role="3cqZAp">
+            <node concept="3cpWsn" id="5bwHbMch6gn" role="1Duv9x">
+              <property role="TrG5h" value="j" />
+              <node concept="10Oyi0" id="5bwHbMch6go" role="1tU5fm" />
+              <node concept="3cpWs3" id="5bwHbMch6gp" role="33vP2m">
+                <node concept="3cmrfG" id="5bwHbMch6gq" role="3uHU7w">
+                  <property role="3cmrfH" value="1" />
+                </node>
+                <node concept="37vLTw" id="5bwHbMch6gr" role="3uHU7B">
+                  <ref role="3cqZAo" node="5bwHbMch6gi" resolve="i" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="5bwHbMch6gs" role="2LFqv$">
+              <node concept="3clFbJ" id="5bwHbMch6gt" role="3cqZAp">
+                <node concept="2OqwBi" id="5bwHbMch6gu" role="3clFbw">
+                  <node concept="1y4W85" id="5bwHbMch6gv" role="2Oq$k0">
+                    <node concept="37vLTw" id="5bwHbMch6gw" role="1y58nS">
+                      <ref role="3cqZAo" node="5bwHbMch6gi" resolve="i" />
+                    </node>
+                    <node concept="2OqwBi" id="5bwHbMch6gx" role="1y566C">
+                      <node concept="1YBJjd" id="5bwHbMch7u5" role="2Oq$k0">
+                        <ref role="1YBMHb" node="5bwHbMch6fM" resolve="dataBlockContainer" />
+                      </node>
+                      <node concept="3Tsc0h" id="5bwHbMch7yC" role="2OqNvi">
+                        <ref role="3TtcxE" to="yvgz:5o1iPWxUm1k" resolve="closures" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2qgKlT" id="5bwHbMch6g$" role="2OqNvi">
+                    <ref role="37wK5l" to="ixp9:5bwHbMcf3ue" resolve="equals" />
+                    <node concept="1y4W85" id="5bwHbMch6g_" role="37wK5m">
+                      <node concept="37vLTw" id="5bwHbMch6gA" role="1y58nS">
+                        <ref role="3cqZAo" node="5bwHbMch6gn" resolve="j" />
+                      </node>
+                      <node concept="2OqwBi" id="5bwHbMch6gB" role="1y566C">
+                        <node concept="1YBJjd" id="5bwHbMch7f7" role="2Oq$k0">
+                          <ref role="1YBMHb" node="5bwHbMch6fM" resolve="dataBlockContainer" />
+                        </node>
+                        <node concept="3Tsc0h" id="5bwHbMch7tn" role="2OqNvi">
+                          <ref role="3TtcxE" to="yvgz:5o1iPWxUm1k" resolve="closures" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbS" id="5bwHbMch6gE" role="3clFbx">
+                  <node concept="2MkqsV" id="5bwHbMch6gF" role="3cqZAp">
+                    <node concept="Xl_RD" id="5bwHbMch6gG" role="2MkJ7o">
+                      <property role="Xl_RC" value="duplicate DataConnector" />
+                    </node>
+                    <node concept="1y4W85" id="5bwHbMch6gH" role="1urrMF">
+                      <node concept="37vLTw" id="5bwHbMch6gI" role="1y58nS">
+                        <ref role="3cqZAo" node="5bwHbMch6gn" resolve="j" />
+                      </node>
+                      <node concept="2OqwBi" id="5bwHbMch6gJ" role="1y566C">
+                        <node concept="1YBJjd" id="5bwHbMch7zJ" role="2Oq$k0">
+                          <ref role="1YBMHb" node="5bwHbMch6fM" resolve="dataBlockContainer" />
+                        </node>
+                        <node concept="3Tsc0h" id="5bwHbMch7BS" role="2OqNvi">
+                          <ref role="3TtcxE" to="yvgz:5o1iPWxUm1k" resolve="closures" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3eOVzh" id="5bwHbMch6gM" role="1Dwp0S">
+              <node concept="2OqwBi" id="5bwHbMch6gN" role="3uHU7w">
+                <node concept="2OqwBi" id="5bwHbMch6gO" role="2Oq$k0">
+                  <node concept="1YBJjd" id="5bwHbMch79n" role="2Oq$k0">
+                    <ref role="1YBMHb" node="5bwHbMch6fM" resolve="dataBlockContainer" />
+                  </node>
+                  <node concept="3Tsc0h" id="5bwHbMch7dY" role="2OqNvi">
+                    <ref role="3TtcxE" to="yvgz:5o1iPWxUm1k" resolve="closures" />
+                  </node>
+                </node>
+                <node concept="34oBXx" id="5bwHbMch6gR" role="2OqNvi" />
+              </node>
+              <node concept="37vLTw" id="5bwHbMch6gS" role="3uHU7B">
+                <ref role="3cqZAo" node="5bwHbMch6gn" resolve="j" />
+              </node>
+            </node>
+            <node concept="3uNrnE" id="5bwHbMch6gT" role="1Dwrff">
+              <node concept="37vLTw" id="5bwHbMch6gU" role="2$L3a6">
+                <ref role="3cqZAo" node="5bwHbMch6gn" resolve="j" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3eOVzh" id="5bwHbMch6gV" role="1Dwp0S">
+          <node concept="3cpWsd" id="5bwHbMch6gW" role="3uHU7w">
+            <node concept="3cmrfG" id="5bwHbMch6gX" role="3uHU7w">
+              <property role="3cmrfH" value="1" />
+            </node>
+            <node concept="2OqwBi" id="5bwHbMch6gY" role="3uHU7B">
+              <node concept="2OqwBi" id="5bwHbMch6gZ" role="2Oq$k0">
+                <node concept="1YBJjd" id="5bwHbMch6NI" role="2Oq$k0">
+                  <ref role="1YBMHb" node="5bwHbMch6fM" resolve="dataBlockContainer" />
+                </node>
+                <node concept="3Tsc0h" id="5bwHbMch785" role="2OqNvi">
+                  <ref role="3TtcxE" to="yvgz:5o1iPWxUm1k" resolve="closures" />
+                </node>
+              </node>
+              <node concept="34oBXx" id="5bwHbMch6h2" role="2OqNvi" />
+            </node>
+          </node>
+          <node concept="37vLTw" id="5bwHbMch6h3" role="3uHU7B">
+            <ref role="3cqZAo" node="5bwHbMch6gi" resolve="i" />
+          </node>
+        </node>
+        <node concept="3uNrnE" id="5bwHbMch6h4" role="1Dwrff">
+          <node concept="37vLTw" id="5bwHbMch6h5" role="2$L3a6">
+            <ref role="3cqZAo" node="5bwHbMch6gi" resolve="i" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="5bwHbMch6fM" role="1YuTPh">
+      <property role="TrG5h" value="dataBlockContainer" />
+      <ref role="1YaFvo" to="yvgz:5o1iPWxUm1h" resolve="DataBlockContainer" />
+    </node>
+  </node>
 </model>
 

--- a/languages/Algorithm/models/Algorithm.typesystem.mps
+++ b/languages/Algorithm/models/Algorithm.typesystem.mps
@@ -15,6 +15,9 @@
       <concept id="1239714755177" name="jetbrains.mps.baseLanguage.structure.AbstractUnaryNumberOperation" flags="nn" index="2$Kvd9">
         <child id="1239714902950" name="expression" index="2$L3a6" />
       </concept>
+      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
+        <child id="1154032183016" name="body" index="2LFqv$" />
+      </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -32,6 +35,7 @@
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
+      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
@@ -49,8 +53,10 @@
       <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
+      <concept id="1068581242869" name="jetbrains.mps.baseLanguage.structure.MinusExpression" flags="nn" index="3cpWsd" />
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1081506762703" name="jetbrains.mps.baseLanguage.structure.GreaterThanExpression" flags="nn" index="3eOSWO" />
+      <concept id="1081506773034" name="jetbrains.mps.baseLanguage.structure.LessThanExpression" flags="nn" index="3eOVzh" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
@@ -61,6 +67,13 @@
       </concept>
       <concept id="1214918800624" name="jetbrains.mps.baseLanguage.structure.PostfixIncrementExpression" flags="nn" index="3uNrnE" />
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+      <concept id="1144230876926" name="jetbrains.mps.baseLanguage.structure.AbstractForStatement" flags="nn" index="1DupvO">
+        <child id="1144230900587" name="variable" index="1Duv9x" />
+      </concept>
+      <concept id="1144231330558" name="jetbrains.mps.baseLanguage.structure.ForStatement" flags="nn" index="1Dw8fO">
+        <child id="1144231399730" name="condition" index="1Dwp0S" />
+        <child id="1144231408325" name="iteration" index="1Dwrff" />
+      </concept>
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
@@ -147,6 +160,10 @@
       <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
+      <concept id="1225711141656" name="jetbrains.mps.baseLanguage.collections.structure.ListElementAccessExpression" flags="nn" index="1y4W85">
+        <child id="1225711182005" name="list" index="1y566C" />
+        <child id="1225711191269" name="index" index="1y58nS" />
+      </concept>
     </language>
   </registry>
   <node concept="18kY7G" id="5jlbthjHQSN">
@@ -380,6 +397,181 @@
     <node concept="1YaCAy" id="5Tr1VsJGw_W" role="1YuTPh">
       <property role="TrG5h" value="fixedDataFlowSchedulerBlock" />
       <ref role="1YaFvo" to="yvgz:3EtQu_veq2" resolve="FixedDataFlowSchedulerBlock" />
+    </node>
+  </node>
+  <node concept="18kY7G" id="5bwHbMcexn1">
+    <property role="TrG5h" value="check_DataConnector" />
+    <node concept="3clFbS" id="5bwHbMcexn2" role="18ibNy">
+      <node concept="3clFbJ" id="5bwHbMcexni" role="3cqZAp">
+        <node concept="3clFbC" id="5bwHbMceykD" role="3clFbw">
+          <node concept="2OqwBi" id="5bwHbMceyEK" role="3uHU7w">
+            <node concept="1YBJjd" id="5bwHbMceyqW" role="2Oq$k0">
+              <ref role="1YBMHb" node="5bwHbMcexn4" resolve="dataConnector" />
+            </node>
+            <node concept="3TrEf2" id="5bwHbMceyG1" role="2OqNvi">
+              <ref role="3Tt5mk" to="yvgz:6po$YwiVFhL" resolve="port2" />
+            </node>
+          </node>
+          <node concept="2OqwBi" id="5bwHbMcexwn" role="3uHU7B">
+            <node concept="1YBJjd" id="5bwHbMcexnu" role="2Oq$k0">
+              <ref role="1YBMHb" node="5bwHbMcexn4" resolve="dataConnector" />
+            </node>
+            <node concept="3TrEf2" id="5bwHbMcexBy" role="2OqNvi">
+              <ref role="3Tt5mk" to="yvgz:6po$YwiVCCg" resolve="port1" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbS" id="5bwHbMcexnk" role="3clFbx">
+          <node concept="2MkqsV" id="5bwHbMceyG$" role="3cqZAp">
+            <node concept="Xl_RD" id="5bwHbMceyGK" role="2MkJ7o">
+              <property role="Xl_RC" value="A DataConnector cannot connect the same port" />
+            </node>
+            <node concept="1YBJjd" id="5bwHbMceyHN" role="1urrMF">
+              <ref role="1YBMHb" node="5bwHbMcexn4" resolve="dataConnector" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="5bwHbMcexn4" role="1YuTPh">
+      <property role="TrG5h" value="dataConnector" />
+      <ref role="1YaFvo" to="yvgz:6po$YwiVCCf" resolve="DataConnector" />
+    </node>
+  </node>
+  <node concept="18kY7G" id="5bwHbMcf7LG">
+    <property role="TrG5h" value="check_FunctionBlockContainer" />
+    <node concept="3clFbS" id="5bwHbMcf7LH" role="18ibNy">
+      <node concept="1Dw8fO" id="5bwHbMcf7M1" role="3cqZAp">
+        <node concept="3cpWsn" id="5bwHbMcf7M2" role="1Duv9x">
+          <property role="TrG5h" value="i" />
+          <node concept="10Oyi0" id="5bwHbMcf7Ma" role="1tU5fm" />
+          <node concept="3cmrfG" id="5bwHbMcfebs" role="33vP2m">
+            <property role="3cmrfH" value="0" />
+          </node>
+        </node>
+        <node concept="3clFbS" id="5bwHbMcf7M3" role="2LFqv$">
+          <node concept="1Dw8fO" id="5bwHbMcfeZF" role="3cqZAp">
+            <node concept="3cpWsn" id="5bwHbMcfeZG" role="1Duv9x">
+              <property role="TrG5h" value="j" />
+              <node concept="10Oyi0" id="5bwHbMcfeZO" role="1tU5fm" />
+              <node concept="3cpWs3" id="5bwHbMcffGa" role="33vP2m">
+                <node concept="3cmrfG" id="5bwHbMcffGd" role="3uHU7w">
+                  <property role="3cmrfH" value="1" />
+                </node>
+                <node concept="37vLTw" id="5bwHbMcff08" role="3uHU7B">
+                  <ref role="3cqZAo" node="5bwHbMcf7M2" resolve="i" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="5bwHbMcfeZH" role="2LFqv$">
+              <node concept="3clFbJ" id="5bwHbMcfnqM" role="3cqZAp">
+                <node concept="2OqwBi" id="5bwHbMcfqGy" role="3clFbw">
+                  <node concept="1y4W85" id="5bwHbMcfqw9" role="2Oq$k0">
+                    <node concept="37vLTw" id="5bwHbMcfq$W" role="1y58nS">
+                      <ref role="3cqZAo" node="5bwHbMcf7M2" resolve="i" />
+                    </node>
+                    <node concept="2OqwBi" id="5bwHbMcfnAZ" role="1y566C">
+                      <node concept="1YBJjd" id="5bwHbMcfnqY" role="2Oq$k0">
+                        <ref role="1YBMHb" node="5bwHbMcf7LJ" resolve="functionBlockContainer" />
+                      </node>
+                      <node concept="3Tsc0h" id="5bwHbMcfnX$" role="2OqNvi">
+                        <ref role="3TtcxE" to="yvgz:4iWYoaWUTso" resolve="closures" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2qgKlT" id="5bwHbMcfqRw" role="2OqNvi">
+                    <ref role="37wK5l" to="ixp9:5bwHbMcf3ue" resolve="equals" />
+                    <node concept="1y4W85" id="5bwHbMcftbM" role="37wK5m">
+                      <node concept="37vLTw" id="5bwHbMcftfy" role="1y58nS">
+                        <ref role="3cqZAo" node="5bwHbMcfeZG" resolve="j" />
+                      </node>
+                      <node concept="2OqwBi" id="5bwHbMcfrbt" role="1y566C">
+                        <node concept="1YBJjd" id="5bwHbMcfqVL" role="2Oq$k0">
+                          <ref role="1YBMHb" node="5bwHbMcf7LJ" resolve="functionBlockContainer" />
+                        </node>
+                        <node concept="3Tsc0h" id="5bwHbMcfryA" role="2OqNvi">
+                          <ref role="3TtcxE" to="yvgz:4iWYoaWUTso" resolve="closures" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbS" id="5bwHbMcfnqO" role="3clFbx">
+                  <node concept="2MkqsV" id="5bwHbMcftj0" role="3cqZAp">
+                    <node concept="Xl_RD" id="5bwHbMcftjc" role="2MkJ7o">
+                      <property role="Xl_RC" value="duplicate DataConnector" />
+                    </node>
+                    <node concept="1y4W85" id="5bwHbMcfvw7" role="1urrMF">
+                      <node concept="37vLTw" id="5bwHbMcfvKd" role="1y58nS">
+                        <ref role="3cqZAo" node="5bwHbMcfeZG" resolve="j" />
+                      </node>
+                      <node concept="2OqwBi" id="5bwHbMcftuH" role="1y566C">
+                        <node concept="1YBJjd" id="5bwHbMcftjG" role="2Oq$k0">
+                          <ref role="1YBMHb" node="5bwHbMcf7LJ" resolve="functionBlockContainer" />
+                        </node>
+                        <node concept="3Tsc0h" id="5bwHbMcftTR" role="2OqNvi">
+                          <ref role="3TtcxE" to="yvgz:4iWYoaWUTso" resolve="closures" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3eOVzh" id="5bwHbMcfgIV" role="1Dwp0S">
+              <node concept="2OqwBi" id="5bwHbMcfjvs" role="3uHU7w">
+                <node concept="2OqwBi" id="5bwHbMcfh99" role="2Oq$k0">
+                  <node concept="1YBJjd" id="5bwHbMcfgJc" role="2Oq$k0">
+                    <ref role="1YBMHb" node="5bwHbMcf7LJ" resolve="functionBlockContainer" />
+                  </node>
+                  <node concept="3Tsc0h" id="5bwHbMcfhu$" role="2OqNvi">
+                    <ref role="3TtcxE" to="yvgz:4iWYoaWUTso" resolve="closures" />
+                  </node>
+                </node>
+                <node concept="34oBXx" id="5bwHbMcfm94" role="2OqNvi" />
+              </node>
+              <node concept="37vLTw" id="5bwHbMcffUh" role="3uHU7B">
+                <ref role="3cqZAo" node="5bwHbMcfeZG" resolve="j" />
+              </node>
+            </node>
+            <node concept="3uNrnE" id="5bwHbMcfmYu" role="1Dwrff">
+              <node concept="37vLTw" id="5bwHbMcfmYw" role="2$L3a6">
+                <ref role="3cqZAo" node="5bwHbMcfeZG" resolve="j" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3eOVzh" id="5bwHbMcf8JX" role="1Dwp0S">
+          <node concept="3cpWsd" id="5bwHbMcfnlX" role="3uHU7w">
+            <node concept="3cmrfG" id="5bwHbMcfnoq" role="3uHU7w">
+              <property role="3cmrfH" value="1" />
+            </node>
+            <node concept="2OqwBi" id="5bwHbMcfbrt" role="3uHU7B">
+              <node concept="2OqwBi" id="5bwHbMcf9cl" role="2Oq$k0">
+                <node concept="1YBJjd" id="5bwHbMcf8Ke" role="2Oq$k0">
+                  <ref role="1YBMHb" node="5bwHbMcf7LJ" resolve="functionBlockContainer" />
+                </node>
+                <node concept="3Tsc0h" id="5bwHbMcf9pg" role="2OqNvi">
+                  <ref role="3TtcxE" to="yvgz:4iWYoaWUTso" resolve="closures" />
+                </node>
+              </node>
+              <node concept="34oBXx" id="5bwHbMcfe1A" role="2OqNvi" />
+            </node>
+          </node>
+          <node concept="37vLTw" id="5bwHbMcf7Mx" role="3uHU7B">
+            <ref role="3cqZAo" node="5bwHbMcf7M2" resolve="i" />
+          </node>
+        </node>
+        <node concept="3uNrnE" id="5bwHbMcfeYj" role="1Dwrff">
+          <node concept="37vLTw" id="5bwHbMcfeYl" role="2$L3a6">
+            <ref role="3cqZAo" node="5bwHbMcf7M2" resolve="i" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="5bwHbMcf7LJ" role="1YuTPh">
+      <property role="TrG5h" value="functionBlockContainer" />
+      <ref role="1YaFvo" to="yvgz:7YUYw4xHlaz" resolve="FunctionBlockContainer" />
     </node>
   </node>
 </model>

--- a/languages/Algorithm/models/Algorithm.typesystem.mps
+++ b/languages/Algorithm/models/Algorithm.typesystem.mps
@@ -84,6 +84,7 @@
         <child id="1144231399730" name="condition" index="1Dwp0S" />
         <child id="1144231408325" name="iteration" index="1Dwrff" />
       </concept>
+      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
@@ -450,6 +451,116 @@
             </node>
             <node concept="1YBJjd" id="5bwHbMceyHN" role="1urrMF">
               <ref role="1YBMHb" node="5bwHbMcexn4" resolve="dataConnector" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="hkK7ztSI8O" role="3cqZAp" />
+      <node concept="3clFbJ" id="hkK7ztSI9i" role="3cqZAp">
+        <node concept="3clFbS" id="hkK7ztSI9k" role="3clFbx">
+          <node concept="2MkqsV" id="hkK7ztSMUm" role="3cqZAp">
+            <node concept="Xl_RD" id="hkK7ztSMU_" role="2MkJ7o">
+              <property role="Xl_RC" value="A DataConnector cannot connect 2 'In' ports" />
+            </node>
+            <node concept="1YBJjd" id="hkK7ztSOlq" role="1urrMF">
+              <ref role="1YBMHb" node="5bwHbMcexn4" resolve="dataConnector" />
+            </node>
+          </node>
+        </node>
+        <node concept="1Wc70l" id="hkK7ztSL0d" role="3clFbw">
+          <node concept="2OqwBi" id="hkK7ztSMSq" role="3uHU7w">
+            <node concept="2OqwBi" id="hkK7ztSMSr" role="2Oq$k0">
+              <node concept="2OqwBi" id="hkK7ztSMSs" role="2Oq$k0">
+                <node concept="1YBJjd" id="hkK7ztSMSt" role="2Oq$k0">
+                  <ref role="1YBMHb" node="5bwHbMcexn4" resolve="dataConnector" />
+                </node>
+                <node concept="3TrEf2" id="hkK7ztSOiW" role="2OqNvi">
+                  <ref role="3Tt5mk" to="yvgz:6po$YwiVFhL" resolve="port2" />
+                </node>
+              </node>
+              <node concept="3TrcHB" id="hkK7ztSMSv" role="2OqNvi">
+                <ref role="3TsBF5" to="yvgz:6po$YwiVCCu" resolve="direction" />
+              </node>
+            </node>
+            <node concept="21noJN" id="hkK7ztSMSw" role="2OqNvi">
+              <node concept="21nZrQ" id="hkK7ztSOkb" role="21noJM">
+                <ref role="21nZrZ" to="yvgz:6po$YwiVCCm" resolve="In" />
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="hkK7ztSNfq" role="3uHU7B">
+            <node concept="2OqwBi" id="hkK7ztSIHE" role="2Oq$k0">
+              <node concept="2OqwBi" id="hkK7ztSIiB" role="2Oq$k0">
+                <node concept="1YBJjd" id="hkK7ztSI9I" role="2Oq$k0">
+                  <ref role="1YBMHb" node="5bwHbMcexn4" resolve="dataConnector" />
+                </node>
+                <node concept="3TrEf2" id="hkK7ztSIyq" role="2OqNvi">
+                  <ref role="3Tt5mk" to="yvgz:6po$YwiVCCg" resolve="port1" />
+                </node>
+              </node>
+              <node concept="3TrcHB" id="hkK7ztSIU0" role="2OqNvi">
+                <ref role="3TsBF5" to="yvgz:6po$YwiVCCu" resolve="direction" />
+              </node>
+            </node>
+            <node concept="21noJN" id="hkK7ztSNAN" role="2OqNvi">
+              <node concept="21nZrQ" id="hkK7ztSNS3" role="21noJM">
+                <ref role="21nZrZ" to="yvgz:6po$YwiVCCm" resolve="In" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="hkK7ztSODM" role="3cqZAp" />
+      <node concept="3clFbJ" id="hkK7ztSODN" role="3cqZAp">
+        <node concept="3clFbS" id="hkK7ztSODO" role="3clFbx">
+          <node concept="2MkqsV" id="hkK7ztSODP" role="3cqZAp">
+            <node concept="Xl_RD" id="hkK7ztSODQ" role="2MkJ7o">
+              <property role="Xl_RC" value="A DataConnector cannot connect 2 'Out' ports" />
+            </node>
+            <node concept="1YBJjd" id="hkK7ztSODR" role="1urrMF">
+              <ref role="1YBMHb" node="5bwHbMcexn4" resolve="dataConnector" />
+            </node>
+          </node>
+        </node>
+        <node concept="1Wc70l" id="hkK7ztSODS" role="3clFbw">
+          <node concept="2OqwBi" id="hkK7ztSODT" role="3uHU7w">
+            <node concept="2OqwBi" id="hkK7ztSODU" role="2Oq$k0">
+              <node concept="2OqwBi" id="hkK7ztSODV" role="2Oq$k0">
+                <node concept="1YBJjd" id="hkK7ztSODW" role="2Oq$k0">
+                  <ref role="1YBMHb" node="5bwHbMcexn4" resolve="dataConnector" />
+                </node>
+                <node concept="3TrEf2" id="hkK7ztSODX" role="2OqNvi">
+                  <ref role="3Tt5mk" to="yvgz:6po$YwiVFhL" resolve="port2" />
+                </node>
+              </node>
+              <node concept="3TrcHB" id="hkK7ztSODY" role="2OqNvi">
+                <ref role="3TsBF5" to="yvgz:6po$YwiVCCu" resolve="direction" />
+              </node>
+            </node>
+            <node concept="21noJN" id="hkK7ztSODZ" role="2OqNvi">
+              <node concept="21nZrQ" id="hkK7ztSOUl" role="21noJM">
+                <ref role="21nZrZ" to="yvgz:6po$YwiVCCn" resolve="Out" />
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="hkK7ztSOE1" role="3uHU7B">
+            <node concept="2OqwBi" id="hkK7ztSOE2" role="2Oq$k0">
+              <node concept="2OqwBi" id="hkK7ztSOE3" role="2Oq$k0">
+                <node concept="1YBJjd" id="hkK7ztSOE4" role="2Oq$k0">
+                  <ref role="1YBMHb" node="5bwHbMcexn4" resolve="dataConnector" />
+                </node>
+                <node concept="3TrEf2" id="hkK7ztSOE5" role="2OqNvi">
+                  <ref role="3Tt5mk" to="yvgz:6po$YwiVCCg" resolve="port1" />
+                </node>
+              </node>
+              <node concept="3TrcHB" id="hkK7ztSOE6" role="2OqNvi">
+                <ref role="3TsBF5" to="yvgz:6po$YwiVCCu" resolve="direction" />
+              </node>
+            </node>
+            <node concept="21noJN" id="hkK7ztSOE7" role="2OqNvi">
+              <node concept="21nZrQ" id="hkK7ztSOTZ" role="21noJM">
+                <ref role="21nZrZ" to="yvgz:6po$YwiVCCn" resolve="Out" />
+              </node>
             </node>
           </node>
         </node>
@@ -889,6 +1000,46 @@
             </node>
             <node concept="Xl_RD" id="hkK7ztHLo2" role="2MkJ7o">
               <property role="Xl_RC" value="A 'TriggerConnector' cannot connect the same port" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbJ" id="hkK7ztSP7A" role="3cqZAp">
+        <node concept="3clFbS" id="hkK7ztSP7C" role="3clFbx">
+          <node concept="2MkqsV" id="hkK7ztSRiC" role="3cqZAp">
+            <node concept="Xl_RD" id="hkK7ztSRiR" role="2MkJ7o">
+              <property role="Xl_RC" value="A 'TriggerConnector' cannot connect ports of the same direction" />
+            </node>
+            <node concept="1YBJjd" id="hkK7ztSRk1" role="1urrMF">
+              <ref role="1YBMHb" node="hkK7ztHKmR" resolve="triggerConnector" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbC" id="hkK7ztSQ1b" role="3clFbw">
+          <node concept="2OqwBi" id="hkK7ztSQS9" role="3uHU7w">
+            <node concept="2OqwBi" id="hkK7ztSQs4" role="2Oq$k0">
+              <node concept="1YBJjd" id="hkK7ztSQ6y" role="2Oq$k0">
+                <ref role="1YBMHb" node="hkK7ztHKmR" resolve="triggerConnector" />
+              </node>
+              <node concept="3TrEf2" id="hkK7ztSQFL" role="2OqNvi">
+                <ref role="3Tt5mk" to="yvgz:6jvQBgXFn51" resolve="port2" />
+              </node>
+            </node>
+            <node concept="3TrcHB" id="hkK7ztSRhr" role="2OqNvi">
+              <ref role="3TsBF5" to="yvgz:3EtQu_tWxu" resolve="direction" />
+            </node>
+          </node>
+          <node concept="2OqwBi" id="hkK7ztSPEq" role="3uHU7B">
+            <node concept="2OqwBi" id="hkK7ztSPgU" role="2Oq$k0">
+              <node concept="1YBJjd" id="hkK7ztSP81" role="2Oq$k0">
+                <ref role="1YBMHb" node="hkK7ztHKmR" resolve="triggerConnector" />
+              </node>
+              <node concept="3TrEf2" id="hkK7ztSPwl" role="2OqNvi">
+                <ref role="3Tt5mk" to="yvgz:6jvQBgXFn4Z" resolve="port1" />
+              </node>
+            </node>
+            <node concept="3TrcHB" id="hkK7ztSPQc" role="2OqNvi">
+              <ref role="3TsBF5" to="yvgz:3EtQu_tWxu" resolve="direction" />
             </node>
           </node>
         </node>

--- a/languages/Algorithm/models/Algorithm.typesystem.mps
+++ b/languages/Algorithm/models/Algorithm.typesystem.mps
@@ -39,6 +39,7 @@
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
         <child id="1068580123160" name="condition" index="3clFbw" />
         <child id="1068580123161" name="ifTrue" index="3clFbx" />
@@ -568,6 +569,134 @@
           </node>
         </node>
       </node>
+      <node concept="1Dw8fO" id="hkK7ztNjl2" role="3cqZAp">
+        <node concept="3cpWsn" id="hkK7ztNjl3" role="1Duv9x">
+          <property role="TrG5h" value="i" />
+          <node concept="10Oyi0" id="hkK7ztNjl4" role="1tU5fm" />
+          <node concept="3cmrfG" id="hkK7ztNjl5" role="33vP2m">
+            <property role="3cmrfH" value="0" />
+          </node>
+        </node>
+        <node concept="3clFbS" id="hkK7ztNjl6" role="2LFqv$">
+          <node concept="1Dw8fO" id="hkK7ztNjl7" role="3cqZAp">
+            <node concept="3cpWsn" id="hkK7ztNjl8" role="1Duv9x">
+              <property role="TrG5h" value="j" />
+              <node concept="10Oyi0" id="hkK7ztNjl9" role="1tU5fm" />
+              <node concept="3cpWs3" id="hkK7ztNjla" role="33vP2m">
+                <node concept="3cmrfG" id="hkK7ztNjlb" role="3uHU7w">
+                  <property role="3cmrfH" value="1" />
+                </node>
+                <node concept="37vLTw" id="hkK7ztNjlc" role="3uHU7B">
+                  <ref role="3cqZAo" node="hkK7ztNjl3" resolve="i" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="hkK7ztNjld" role="2LFqv$">
+              <node concept="3clFbJ" id="hkK7ztNjle" role="3cqZAp">
+                <node concept="2OqwBi" id="hkK7ztNjlf" role="3clFbw">
+                  <node concept="1y4W85" id="hkK7ztNGAg" role="2Oq$k0">
+                    <node concept="37vLTw" id="hkK7ztNGR8" role="1y58nS">
+                      <ref role="3cqZAo" node="hkK7ztNjl3" resolve="i" />
+                    </node>
+                    <node concept="2OqwBi" id="hkK7ztNjli" role="1y566C">
+                      <node concept="1YBJjd" id="hkK7ztNjlj" role="2Oq$k0">
+                        <ref role="1YBMHb" node="5bwHbMcf7LJ" resolve="functionBlockContainer" />
+                      </node>
+                      <node concept="3Tsc0h" id="hkK7ztNmGz" role="2OqNvi">
+                        <ref role="3TtcxE" to="yvgz:6jvQBgXFn54" resolve="triggers" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2qgKlT" id="hkK7ztNjll" role="2OqNvi">
+                    <ref role="37wK5l" to="ixp9:hkK7ztNhQC" resolve="equals" />
+                    <node concept="1y4W85" id="hkK7ztNJ01" role="37wK5m">
+                      <node concept="37vLTw" id="hkK7ztNJaw" role="1y58nS">
+                        <ref role="3cqZAo" node="hkK7ztNjl8" resolve="j" />
+                      </node>
+                      <node concept="2OqwBi" id="hkK7ztNjlo" role="1y566C">
+                        <node concept="1YBJjd" id="hkK7ztNjlp" role="2Oq$k0">
+                          <ref role="1YBMHb" node="5bwHbMcf7LJ" resolve="functionBlockContainer" />
+                        </node>
+                        <node concept="3Tsc0h" id="hkK7ztNHsC" role="2OqNvi">
+                          <ref role="3TtcxE" to="yvgz:6jvQBgXFn54" resolve="triggers" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbS" id="hkK7ztNjlr" role="3clFbx">
+                  <node concept="2MkqsV" id="hkK7ztNjls" role="3cqZAp">
+                    <node concept="Xl_RD" id="hkK7ztNjlt" role="2MkJ7o">
+                      <property role="Xl_RC" value="duplicate TriggerConnector" />
+                    </node>
+                    <node concept="1y4W85" id="hkK7ztNjlu" role="1urrMF">
+                      <node concept="37vLTw" id="hkK7ztNjlv" role="1y58nS">
+                        <ref role="3cqZAo" node="hkK7ztNjl8" resolve="j" />
+                      </node>
+                      <node concept="2OqwBi" id="hkK7ztNjlw" role="1y566C">
+                        <node concept="1YBJjd" id="hkK7ztNjlx" role="2Oq$k0">
+                          <ref role="1YBMHb" node="5bwHbMcf7LJ" resolve="functionBlockContainer" />
+                        </node>
+                        <node concept="3Tsc0h" id="hkK7ztNmSH" role="2OqNvi">
+                          <ref role="3TtcxE" to="yvgz:6jvQBgXFn54" resolve="triggers" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3eOVzh" id="hkK7ztNjlz" role="1Dwp0S">
+              <node concept="2OqwBi" id="hkK7ztNjl$" role="3uHU7w">
+                <node concept="2OqwBi" id="hkK7ztNjl_" role="2Oq$k0">
+                  <node concept="1YBJjd" id="hkK7ztNjlA" role="2Oq$k0">
+                    <ref role="1YBMHb" node="5bwHbMcf7LJ" resolve="functionBlockContainer" />
+                  </node>
+                  <node concept="3Tsc0h" id="hkK7ztNmF5" role="2OqNvi">
+                    <ref role="3TtcxE" to="yvgz:6jvQBgXFn54" resolve="triggers" />
+                  </node>
+                </node>
+                <node concept="34oBXx" id="hkK7ztNjlC" role="2OqNvi" />
+              </node>
+              <node concept="37vLTw" id="hkK7ztNjlD" role="3uHU7B">
+                <ref role="3cqZAo" node="hkK7ztNjl8" resolve="j" />
+              </node>
+            </node>
+            <node concept="3uNrnE" id="hkK7ztNjlE" role="1Dwrff">
+              <node concept="37vLTw" id="hkK7ztNjlF" role="2$L3a6">
+                <ref role="3cqZAo" node="hkK7ztNjl8" resolve="j" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3eOVzh" id="hkK7ztNjlG" role="1Dwp0S">
+          <node concept="3cpWsd" id="hkK7ztNjlH" role="3uHU7w">
+            <node concept="3cmrfG" id="hkK7ztNjlI" role="3uHU7w">
+              <property role="3cmrfH" value="1" />
+            </node>
+            <node concept="2OqwBi" id="hkK7ztNjlJ" role="3uHU7B">
+              <node concept="2OqwBi" id="hkK7ztNjlK" role="2Oq$k0">
+                <node concept="1YBJjd" id="hkK7ztNjlL" role="2Oq$k0">
+                  <ref role="1YBMHb" node="5bwHbMcf7LJ" resolve="functionBlockContainer" />
+                </node>
+                <node concept="3Tsc0h" id="hkK7ztNk6w" role="2OqNvi">
+                  <ref role="3TtcxE" to="yvgz:6jvQBgXFn54" resolve="triggers" />
+                </node>
+              </node>
+              <node concept="34oBXx" id="hkK7ztNjlN" role="2OqNvi" />
+            </node>
+          </node>
+          <node concept="37vLTw" id="hkK7ztNjlO" role="3uHU7B">
+            <ref role="3cqZAo" node="hkK7ztNjl3" resolve="i" />
+          </node>
+        </node>
+        <node concept="3uNrnE" id="hkK7ztNjlP" role="1Dwrff">
+          <node concept="37vLTw" id="hkK7ztNjlQ" role="2$L3a6">
+            <ref role="3cqZAo" node="hkK7ztNjl3" resolve="i" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="hkK7ztNjdG" role="3cqZAp" />
     </node>
     <node concept="1YaCAy" id="5bwHbMcf7LJ" role="1YuTPh">
       <property role="TrG5h" value="functionBlockContainer" />
@@ -708,6 +837,45 @@
     <node concept="1YaCAy" id="5bwHbMch6fM" role="1YuTPh">
       <property role="TrG5h" value="dataBlockContainer" />
       <ref role="1YaFvo" to="yvgz:5o1iPWxUm1h" resolve="DataBlockContainer" />
+    </node>
+  </node>
+  <node concept="18kY7G" id="hkK7ztHKmO">
+    <property role="TrG5h" value="check_TriggerConnector" />
+    <node concept="3clFbS" id="hkK7ztHKmP" role="18ibNy">
+      <node concept="3clFbJ" id="hkK7ztHKn0" role="3cqZAp">
+        <node concept="3clFbC" id="hkK7ztHKTt" role="3clFbw">
+          <node concept="2OqwBi" id="hkK7ztHLf4" role="3uHU7w">
+            <node concept="1YBJjd" id="hkK7ztHKZo" role="2Oq$k0">
+              <ref role="1YBMHb" node="hkK7ztHKmR" resolve="triggerConnector" />
+            </node>
+            <node concept="3TrEf2" id="hkK7ztHLg0" role="2OqNvi">
+              <ref role="3Tt5mk" to="yvgz:6jvQBgXFn51" resolve="port2" />
+            </node>
+          </node>
+          <node concept="2OqwBi" id="hkK7ztHKw5" role="3uHU7B">
+            <node concept="1YBJjd" id="hkK7ztHKnc" role="2Oq$k0">
+              <ref role="1YBMHb" node="hkK7ztHKmR" resolve="triggerConnector" />
+            </node>
+            <node concept="3TrEf2" id="hkK7ztHKAV" role="2OqNvi">
+              <ref role="3Tt5mk" to="yvgz:6jvQBgXFn4Z" resolve="port1" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbS" id="hkK7ztHKn2" role="3clFbx">
+          <node concept="2MkqsV" id="hkK7ztHLgz" role="3cqZAp">
+            <node concept="1YBJjd" id="hkK7ztHLoy" role="1urrMF">
+              <ref role="1YBMHb" node="hkK7ztHKmR" resolve="triggerConnector" />
+            </node>
+            <node concept="Xl_RD" id="hkK7ztHLo2" role="2MkJ7o">
+              <property role="Xl_RC" value="A 'TriggerConnector' cannot connect the same port" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="hkK7ztHKmR" role="1YuTPh">
+      <property role="TrG5h" value="triggerConnector" />
+      <ref role="1YaFvo" to="yvgz:6jvQBgXFn4Y" resolve="TriggerConnector" />
     </node>
   </node>
 </model>

--- a/languages/Algorithm/models/Algorithm.typesystem.mps
+++ b/languages/Algorithm/models/Algorithm.typesystem.mps
@@ -8,9 +8,13 @@
   <imports>
     <import index="yvgz" ref="r:3b411c10-569a-4299-9505-176144359d3b(Algorithm.structure)" implicit="true" />
     <import index="ixp9" ref="r:172690fd-5286-4218-b525-cadaaf47af22(Algorithm.behavior)" implicit="true" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
+        <child id="1082485599096" name="statements" index="9aQI4" />
+      </concept>
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1239714755177" name="jetbrains.mps.baseLanguage.structure.AbstractUnaryNumberOperation" flags="nn" index="2$Kvd9">
         <child id="1239714902950" name="expression" index="2$L3a6" />
@@ -22,6 +26,9 @@
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
       </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
@@ -32,6 +39,7 @@
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -41,6 +49,7 @@
       </concept>
       <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
         <child id="1068580123160" name="condition" index="3clFbw" />
         <child id="1068580123161" name="ifTrue" index="3clFbx" />
       </concept>
@@ -158,13 +167,25 @@
       <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
         <child id="1204796294226" name="closure" index="23t8la" />
       </concept>
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
+        <child id="540871147943773366" name="argument" index="25WWJ7" />
+      </concept>
       <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
+      <concept id="1226511727824" name="jetbrains.mps.baseLanguage.collections.structure.SetType" flags="in" index="2hMVRd">
+        <child id="1226511765987" name="elementType" index="2hN53Y" />
+      </concept>
+      <concept id="1226516258405" name="jetbrains.mps.baseLanguage.collections.structure.HashSetCreator" flags="nn" index="2i4dXS" />
+      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
+        <child id="1237721435807" name="elementType" index="HW$YZ" />
+      </concept>
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
+      <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1225711141656" name="jetbrains.mps.baseLanguage.collections.structure.ListElementAccessExpression" flags="nn" index="1y4W85">
         <child id="1225711182005" name="list" index="1y566C" />
         <child id="1225711191269" name="index" index="1y58nS" />
       </concept>
+      <concept id="1172254888721" name="jetbrains.mps.baseLanguage.collections.structure.ContainsOperation" flags="nn" index="3JPx81" />
     </language>
   </registry>
   <node concept="18kY7G" id="5jlbthjHQSN">
@@ -876,6 +897,274 @@
     <node concept="1YaCAy" id="hkK7ztHKmR" role="1YuTPh">
       <property role="TrG5h" value="triggerConnector" />
       <ref role="1YaFvo" to="yvgz:6jvQBgXFn4Y" resolve="TriggerConnector" />
+    </node>
+  </node>
+  <node concept="18kY7G" id="hkK7ztOYgj">
+    <property role="TrG5h" value="check_FunctionBlock" />
+    <node concept="3clFbS" id="hkK7ztOYgk" role="18ibNy">
+      <node concept="3cpWs8" id="hkK7ztOZRc" role="3cqZAp">
+        <node concept="3cpWsn" id="hkK7ztOZRf" role="3cpWs9">
+          <property role="TrG5h" value="dataPortNames" />
+          <node concept="2hMVRd" id="hkK7ztOZRa" role="1tU5fm">
+            <node concept="17QB3L" id="hkK7ztOZRq" role="2hN53Y" />
+          </node>
+          <node concept="2ShNRf" id="hkK7ztOZS3" role="33vP2m">
+            <node concept="2i4dXS" id="hkK7ztOZRY" role="2ShVmc">
+              <node concept="17QB3L" id="hkK7ztOZRZ" role="HW$YZ" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbF" id="hkK7ztOZTj" role="3cqZAp">
+        <node concept="2OqwBi" id="hkK7ztP28d" role="3clFbG">
+          <node concept="2OqwBi" id="hkK7ztP01V" role="2Oq$k0">
+            <node concept="1YBJjd" id="hkK7ztOZTh" role="2Oq$k0">
+              <ref role="1YBMHb" node="hkK7ztOYgm" resolve="functionBlock" />
+            </node>
+            <node concept="3Tsc0h" id="hkK7ztP0b_" role="2OqNvi">
+              <ref role="3TtcxE" to="yvgz:3eP8Zudp5G8" resolve="data_ports" />
+            </node>
+          </node>
+          <node concept="2es0OD" id="hkK7ztP4jB" role="2OqNvi">
+            <node concept="1bVj0M" id="hkK7ztP4jD" role="23t8la">
+              <node concept="3clFbS" id="hkK7ztP4jE" role="1bW5cS">
+                <node concept="3clFbJ" id="hkK7ztP4s8" role="3cqZAp">
+                  <node concept="2OqwBi" id="hkK7ztP5bZ" role="3clFbw">
+                    <node concept="37vLTw" id="hkK7ztP4ut" role="2Oq$k0">
+                      <ref role="3cqZAo" node="hkK7ztOZRf" resolve="dataPortNames" />
+                    </node>
+                    <node concept="3JPx81" id="hkK7ztP65P" role="2OqNvi">
+                      <node concept="2OqwBi" id="hkK7ztP6if" role="25WWJ7">
+                        <node concept="37vLTw" id="hkK7ztP6aL" role="2Oq$k0">
+                          <ref role="3cqZAo" node="hkK7ztP4jF" resolve="dataPort" />
+                        </node>
+                        <node concept="3TrcHB" id="hkK7ztP6vP" role="2OqNvi">
+                          <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbS" id="hkK7ztP4sa" role="3clFbx">
+                    <node concept="2MkqsV" id="hkK7ztP6$W" role="3cqZAp">
+                      <node concept="Xl_RD" id="hkK7ztP6C0" role="2MkJ7o">
+                        <property role="Xl_RC" value="data port name must be unique" />
+                      </node>
+                      <node concept="37vLTw" id="hkK7ztP74e" role="1urrMF">
+                        <ref role="3cqZAo" node="hkK7ztP4jF" resolve="dataPort" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="9aQIb" id="hkK7ztP7kq" role="9aQIa">
+                    <node concept="3clFbS" id="hkK7ztP7kr" role="9aQI4">
+                      <node concept="3clFbF" id="hkK7ztP7nv" role="3cqZAp">
+                        <node concept="2OqwBi" id="hkK7ztP7YF" role="3clFbG">
+                          <node concept="37vLTw" id="hkK7ztP7nu" role="2Oq$k0">
+                            <ref role="3cqZAo" node="hkK7ztOZRf" resolve="dataPortNames" />
+                          </node>
+                          <node concept="TSZUe" id="hkK7ztP8Az" role="2OqNvi">
+                            <node concept="2OqwBi" id="hkK7ztP8Y_" role="25WWJ7">
+                              <node concept="37vLTw" id="hkK7ztP8JG" role="2Oq$k0">
+                                <ref role="3cqZAo" node="hkK7ztP4jF" resolve="dataPort" />
+                              </node>
+                              <node concept="3TrcHB" id="hkK7ztP99m" role="2OqNvi">
+                                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="Rh6nW" id="hkK7ztP4jF" role="1bW2Oz">
+                <property role="TrG5h" value="dataPort" />
+                <node concept="2jxLKc" id="hkK7ztP4jG" role="1tU5fm" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="hkK7ztP9gK" role="3cqZAp" />
+      <node concept="3cpWs8" id="hkK7ztP9ij" role="3cqZAp">
+        <node concept="3cpWsn" id="hkK7ztP9im" role="3cpWs9">
+          <property role="TrG5h" value="triggerPortNames" />
+          <node concept="2hMVRd" id="hkK7ztP9if" role="1tU5fm">
+            <node concept="17QB3L" id="hkK7ztP9jf" role="2hN53Y" />
+          </node>
+          <node concept="2ShNRf" id="hkK7ztP9jU" role="33vP2m">
+            <node concept="2i4dXS" id="hkK7ztP9jP" role="2ShVmc">
+              <node concept="17QB3L" id="hkK7ztP9jQ" role="HW$YZ" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbF" id="hkK7ztP9lh" role="3cqZAp">
+        <node concept="2OqwBi" id="hkK7ztPbna" role="3clFbG">
+          <node concept="2OqwBi" id="hkK7ztP9uB" role="2Oq$k0">
+            <node concept="1YBJjd" id="hkK7ztP9lf" role="2Oq$k0">
+              <ref role="1YBMHb" node="hkK7ztOYgm" resolve="functionBlock" />
+            </node>
+            <node concept="3Tsc0h" id="hkK7ztP9MR" role="2OqNvi">
+              <ref role="3TtcxE" to="yvgz:3eP8Zudp5Gb" resolve="trigger_ports" />
+            </node>
+          </node>
+          <node concept="2es0OD" id="hkK7ztPdU0" role="2OqNvi">
+            <node concept="1bVj0M" id="hkK7ztPdU2" role="23t8la">
+              <node concept="3clFbS" id="hkK7ztPdU3" role="1bW5cS">
+                <node concept="3clFbJ" id="hkK7ztPe5b" role="3cqZAp">
+                  <node concept="2OqwBi" id="hkK7ztPeP0" role="3clFbw">
+                    <node concept="37vLTw" id="hkK7ztPe7v" role="2Oq$k0">
+                      <ref role="3cqZAo" node="hkK7ztP9im" resolve="triggerPortNames" />
+                    </node>
+                    <node concept="3JPx81" id="hkK7ztPft7" role="2OqNvi">
+                      <node concept="2OqwBi" id="hkK7ztPfGi" role="25WWJ7">
+                        <node concept="37vLTw" id="hkK7ztPfvT" role="2Oq$k0">
+                          <ref role="3cqZAo" node="hkK7ztPdU4" resolve="triggerPort" />
+                        </node>
+                        <node concept="3TrcHB" id="hkK7ztPfRD" role="2OqNvi">
+                          <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbS" id="hkK7ztPe5d" role="3clFbx">
+                    <node concept="2MkqsV" id="hkK7ztPfWA" role="3cqZAp">
+                      <node concept="Xl_RD" id="hkK7ztPfZD" role="2MkJ7o">
+                        <property role="Xl_RC" value="trigger port name must be unique" />
+                      </node>
+                      <node concept="37vLTw" id="hkK7ztPgoC" role="1urrMF">
+                        <ref role="3cqZAo" node="hkK7ztPdU4" resolve="triggerPort" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="9aQIb" id="hkK7ztPgrJ" role="9aQIa">
+                    <node concept="3clFbS" id="hkK7ztPgrK" role="9aQI4">
+                      <node concept="3clFbF" id="hkK7ztPgzY" role="3cqZAp">
+                        <node concept="2OqwBi" id="hkK7ztPhb9" role="3clFbG">
+                          <node concept="37vLTw" id="hkK7ztPgzX" role="2Oq$k0">
+                            <ref role="3cqZAo" node="hkK7ztP9im" resolve="triggerPortNames" />
+                          </node>
+                          <node concept="TSZUe" id="hkK7ztPhMZ" role="2OqNvi">
+                            <node concept="2OqwBi" id="hkK7ztPifL" role="25WWJ7">
+                              <node concept="37vLTw" id="hkK7ztPhW7" role="2Oq$k0">
+                                <ref role="3cqZAo" node="hkK7ztPdU4" resolve="triggerPort" />
+                              </node>
+                              <node concept="3TrcHB" id="hkK7ztPisQ" role="2OqNvi">
+                                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="Rh6nW" id="hkK7ztPdU4" role="1bW2Oz">
+                <property role="TrG5h" value="triggerPort" />
+                <node concept="2jxLKc" id="hkK7ztPdU5" role="1tU5fm" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="hkK7ztOYgm" role="1YuTPh">
+      <property role="TrG5h" value="functionBlock" />
+      <ref role="1YaFvo" to="yvgz:3eP8Zudp5G4" resolve="FunctionBlock" />
+    </node>
+  </node>
+  <node concept="18kY7G" id="hkK7ztQ45r">
+    <property role="TrG5h" value="check_DataBlock" />
+    <node concept="3clFbS" id="hkK7ztQ45s" role="18ibNy">
+      <node concept="3cpWs8" id="hkK7ztQ4W6" role="3cqZAp">
+        <node concept="3cpWsn" id="hkK7ztQ4W7" role="3cpWs9">
+          <property role="TrG5h" value="dataPortNames" />
+          <node concept="2hMVRd" id="hkK7ztQ4W8" role="1tU5fm">
+            <node concept="17QB3L" id="hkK7ztQ4W9" role="2hN53Y" />
+          </node>
+          <node concept="2ShNRf" id="hkK7ztQ4Wa" role="33vP2m">
+            <node concept="2i4dXS" id="hkK7ztQ4Wb" role="2ShVmc">
+              <node concept="17QB3L" id="hkK7ztQ4Wc" role="HW$YZ" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbF" id="hkK7ztQ4Wd" role="3cqZAp">
+        <node concept="2OqwBi" id="hkK7ztQ4We" role="3clFbG">
+          <node concept="2OqwBi" id="hkK7ztQ4Wf" role="2Oq$k0">
+            <node concept="1YBJjd" id="hkK7ztQ5_8" role="2Oq$k0">
+              <ref role="1YBMHb" node="hkK7ztQ45u" resolve="dataBlock" />
+            </node>
+            <node concept="3Tsc0h" id="hkK7ztQ67d" role="2OqNvi">
+              <ref role="3TtcxE" to="yvgz:6jvQBgXExiw" resolve="ports" />
+            </node>
+          </node>
+          <node concept="2es0OD" id="hkK7ztQ4Wi" role="2OqNvi">
+            <node concept="1bVj0M" id="hkK7ztQ4Wj" role="23t8la">
+              <node concept="3clFbS" id="hkK7ztQ4Wk" role="1bW5cS">
+                <node concept="3clFbJ" id="hkK7ztQ4Wl" role="3cqZAp">
+                  <node concept="2OqwBi" id="hkK7ztQ4Wm" role="3clFbw">
+                    <node concept="37vLTw" id="hkK7ztQ4Wn" role="2Oq$k0">
+                      <ref role="3cqZAo" node="hkK7ztQ4W7" resolve="dataPortNames" />
+                    </node>
+                    <node concept="3JPx81" id="hkK7ztQ4Wo" role="2OqNvi">
+                      <node concept="2OqwBi" id="hkK7ztQ4Wp" role="25WWJ7">
+                        <node concept="37vLTw" id="hkK7ztQ4Wq" role="2Oq$k0">
+                          <ref role="3cqZAo" node="hkK7ztQ4WD" resolve="dataPort" />
+                        </node>
+                        <node concept="3TrcHB" id="hkK7ztQ4Wr" role="2OqNvi">
+                          <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbS" id="hkK7ztQ4Ws" role="3clFbx">
+                    <node concept="2MkqsV" id="hkK7ztQ4Wt" role="3cqZAp">
+                      <node concept="Xl_RD" id="hkK7ztQ4Wu" role="2MkJ7o">
+                        <property role="Xl_RC" value="data port name must be unique" />
+                      </node>
+                      <node concept="37vLTw" id="hkK7ztQ4Wv" role="1urrMF">
+                        <ref role="3cqZAo" node="hkK7ztQ4WD" resolve="dataPort" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="9aQIb" id="hkK7ztQ4Ww" role="9aQIa">
+                    <node concept="3clFbS" id="hkK7ztQ4Wx" role="9aQI4">
+                      <node concept="3clFbF" id="hkK7ztQ4Wy" role="3cqZAp">
+                        <node concept="2OqwBi" id="hkK7ztQ4Wz" role="3clFbG">
+                          <node concept="37vLTw" id="hkK7ztQ4W$" role="2Oq$k0">
+                            <ref role="3cqZAo" node="hkK7ztQ4W7" resolve="dataPortNames" />
+                          </node>
+                          <node concept="TSZUe" id="hkK7ztQ4W_" role="2OqNvi">
+                            <node concept="2OqwBi" id="hkK7ztQ4WA" role="25WWJ7">
+                              <node concept="37vLTw" id="hkK7ztQ4WB" role="2Oq$k0">
+                                <ref role="3cqZAo" node="hkK7ztQ4WD" resolve="dataPort" />
+                              </node>
+                              <node concept="3TrcHB" id="hkK7ztQ4WC" role="2OqNvi">
+                                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="Rh6nW" id="hkK7ztQ4WD" role="1bW2Oz">
+                <property role="TrG5h" value="dataPort" />
+                <node concept="2jxLKc" id="hkK7ztQ4WE" role="1tU5fm" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="hkK7ztQ45u" role="1YuTPh">
+      <property role="TrG5h" value="dataBlock" />
+      <ref role="1YaFvo" to="yvgz:29RmJoXeePk" resolve="DataBlock" />
     </node>
   </node>
 </model>

--- a/solutions/Algorithm.sandbox/models/Algorithm.sandbox.mps
+++ b/solutions/Algorithm.sandbox/models/Algorithm.sandbox.mps
@@ -356,8 +356,8 @@
         <ref role="1OHyup" node="44Cv2OMFVOU" resolve="parent_a_port" />
       </node>
       <node concept="1OHxBB" id="44Cv2OMFVPw" role="1RU2Gb">
-        <ref role="1OHxBS" node="44Cv2OMFVJ9" resolve="child_port_b" />
         <ref role="1OHyup" node="44Cv2OMFVP1" resolve="parent_b_port" />
+        <ref role="1OHxBS" node="44Cv2OMFVJ9" resolve="child_port_b" />
       </node>
       <node concept="1OHxBU" id="44Cv2OMFVOU" role="1ptsVk">
         <property role="TrG5h" value="parent_a_port" />


### PR DESCRIPTION
This PR introduces the following constraints:
- `DataConnector` and `TriggerConnector` should not connect a port to itself (type checking rule)
- `FunctionBlockContainer` and `DataBlockContainer` should not have duplicate `DataConnector` (type checking rule)
- `FunctionBlockContainer` should not have duplicate `TriggerConnector` (type checking rule)
- `FunctionBlock` should have unique names for `DataPort`'s and `TriggerPort`'s, `DataBlock` should have unique names for `DataPort`'s

partially handles #5 