### PR TITLE
add unconnected port constraints

### DIFF
--- a/languages/Algorithm/models/Algorithm.behavior.mps
+++ b/languages/Algorithm/models/Algorithm.behavior.mps
@@ -1227,6 +1227,132 @@
         </node>
       </node>
     </node>
+    <node concept="13i0hz" id="4LsB5Tjos1C" role="13h7CS">
+      <property role="TrG5h" value="findConnectedDataPorts" />
+      <node concept="3Tm1VV" id="4LsB5Tjos1D" role="1B3o_S" />
+      <node concept="2I9FWS" id="4LsB5Tjos1E" role="3clF45">
+        <ref role="2I9WkF" to="yvgz:6po$YwiVCCi" resolve="DataPort" />
+      </node>
+      <node concept="3clFbS" id="4LsB5Tjos1F" role="3clF47">
+        <node concept="3cpWs8" id="4LsB5Tjos1G" role="3cqZAp">
+          <node concept="3cpWsn" id="4LsB5Tjos1H" role="3cpWs9">
+            <property role="TrG5h" value="dataPorts" />
+            <node concept="2I9FWS" id="4LsB5Tjos1I" role="1tU5fm">
+              <ref role="2I9WkF" to="yvgz:6po$YwiVCCi" resolve="DataPort" />
+            </node>
+            <node concept="2ShNRf" id="4LsB5Tjos1J" role="33vP2m">
+              <node concept="2T8Vx0" id="4LsB5Tjos1K" role="2ShVmc">
+                <node concept="2I9FWS" id="4LsB5Tjos1L" role="2T96Bj">
+                  <ref role="2I9WkF" to="yvgz:6po$YwiVCCi" resolve="DataPort" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2Gpval" id="4LsB5Tjos1M" role="3cqZAp">
+          <node concept="2GrKxI" id="4LsB5Tjos1N" role="2Gsz3X">
+            <property role="TrG5h" value="dataConnector" />
+          </node>
+          <node concept="2OqwBi" id="4LsB5Tjos1O" role="2GsD0m">
+            <node concept="13iPFW" id="4LsB5Tjos1P" role="2Oq$k0" />
+            <node concept="3Tsc0h" id="4LsB5Tjos1Q" role="2OqNvi">
+              <ref role="3TtcxE" to="yvgz:5o1iPWxUm1k" resolve="closures" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="4LsB5Tjos1R" role="2LFqv$">
+            <node concept="3clFbJ" id="4LsB5Tjos1S" role="3cqZAp">
+              <node concept="3clFbC" id="4LsB5Tjos1T" role="3clFbw">
+                <node concept="37vLTw" id="4LsB5Tjos1U" role="3uHU7w">
+                  <ref role="3cqZAo" node="4LsB5Tjos2q" resolve="dataPort" />
+                </node>
+                <node concept="2OqwBi" id="4LsB5Tjos1V" role="3uHU7B">
+                  <node concept="2GrUjf" id="4LsB5Tjos1W" role="2Oq$k0">
+                    <ref role="2Gs0qQ" node="4LsB5Tjos1N" resolve="dataConnector" />
+                  </node>
+                  <node concept="3TrEf2" id="4LsB5Tjoy6Q" role="2OqNvi">
+                    <ref role="3Tt5mk" to="yvgz:6po$YwiVCCg" resolve="port1" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbS" id="4LsB5Tjos1Y" role="3clFbx">
+                <node concept="3clFbF" id="4LsB5Tjos1Z" role="3cqZAp">
+                  <node concept="2OqwBi" id="4LsB5Tjos20" role="3clFbG">
+                    <node concept="37vLTw" id="4LsB5Tjos21" role="2Oq$k0">
+                      <ref role="3cqZAo" node="4LsB5Tjos1H" resolve="dataPorts" />
+                    </node>
+                    <node concept="TSZUe" id="4LsB5Tjos22" role="2OqNvi">
+                      <node concept="2OqwBi" id="4LsB5Tjos23" role="25WWJ7">
+                        <node concept="2OqwBi" id="4LsB5Tjos24" role="2Oq$k0">
+                          <node concept="2GrUjf" id="4LsB5Tjos25" role="2Oq$k0">
+                            <ref role="2Gs0qQ" node="4LsB5Tjos1N" resolve="dataConnector" />
+                          </node>
+                          <node concept="3TrEf2" id="4LsB5Tjos26" role="2OqNvi">
+                            <ref role="3Tt5mk" to="yvgz:6po$YwiVFhL" resolve="port2" />
+                          </node>
+                        </node>
+                        <node concept="2qgKlT" id="4LsB5Tjos27" role="2OqNvi">
+                          <ref role="37wK5l" node="2FsRs4zDsXN" resolve="getPortRecursive" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3eNFk2" id="4LsB5Tjos28" role="3eNLev">
+                <node concept="3clFbS" id="4LsB5Tjos29" role="3eOfB_">
+                  <node concept="3clFbF" id="4LsB5Tjos2a" role="3cqZAp">
+                    <node concept="2OqwBi" id="4LsB5Tjos2b" role="3clFbG">
+                      <node concept="37vLTw" id="4LsB5Tjos2c" role="2Oq$k0">
+                        <ref role="3cqZAo" node="4LsB5Tjos1H" resolve="dataPorts" />
+                      </node>
+                      <node concept="TSZUe" id="4LsB5Tjos2d" role="2OqNvi">
+                        <node concept="2OqwBi" id="4LsB5Tjos2e" role="25WWJ7">
+                          <node concept="2OqwBi" id="4LsB5Tjos2f" role="2Oq$k0">
+                            <node concept="2GrUjf" id="4LsB5Tjos2g" role="2Oq$k0">
+                              <ref role="2Gs0qQ" node="4LsB5Tjos1N" resolve="dataConnector" />
+                            </node>
+                            <node concept="3TrEf2" id="4LsB5Tjos2h" role="2OqNvi">
+                              <ref role="3Tt5mk" to="yvgz:6po$YwiVCCg" resolve="port1" />
+                            </node>
+                          </node>
+                          <node concept="2qgKlT" id="4LsB5Tjos2i" role="2OqNvi">
+                            <ref role="37wK5l" node="2FsRs4zDsXN" resolve="getPortRecursive" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbC" id="4LsB5Tjos2j" role="3eO9$A">
+                  <node concept="37vLTw" id="4LsB5Tjos2k" role="3uHU7w">
+                    <ref role="3cqZAo" node="4LsB5Tjos2q" resolve="dataPort" />
+                  </node>
+                  <node concept="2OqwBi" id="4LsB5Tjos2l" role="3uHU7B">
+                    <node concept="2GrUjf" id="4LsB5Tjos2m" role="2Oq$k0">
+                      <ref role="2Gs0qQ" node="4LsB5Tjos1N" resolve="dataConnector" />
+                    </node>
+                    <node concept="3TrEf2" id="4LsB5Tjos2n" role="2OqNvi">
+                      <ref role="3Tt5mk" to="yvgz:6po$YwiVFhL" resolve="port2" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="4LsB5Tjos2o" role="3cqZAp">
+          <node concept="37vLTw" id="4LsB5Tjos2p" role="3cqZAk">
+            <ref role="3cqZAo" node="4LsB5Tjos1H" resolve="dataPorts" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="4LsB5Tjos2q" role="3clF46">
+        <property role="TrG5h" value="dataPort" />
+        <node concept="3Tqbb2" id="4LsB5Tjos2r" role="1tU5fm">
+          <ref role="ehGHo" to="yvgz:6po$YwiVCCi" resolve="DataPort" />
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="13h7C7" id="5bwHbMcf3tV">
     <ref role="13h7C2" to="yvgz:6po$YwiVCCf" resolve="DataConnector" />

--- a/languages/Algorithm/models/Algorithm.typesystem.mps
+++ b/languages/Algorithm/models/Algorithm.typesystem.mps
@@ -1592,6 +1592,202 @@
           </node>
         </node>
       </node>
+      <node concept="3clFbH" id="4LsB5Tjq8F3" role="3cqZAp" />
+      <node concept="3clFbJ" id="4LsB5Tjq8HZ" role="3cqZAp">
+        <node concept="3clFbS" id="4LsB5Tjq8I1" role="3clFbx">
+          <node concept="3cpWs8" id="4LsB5Tjqad2" role="3cqZAp">
+            <node concept="3cpWsn" id="4LsB5Tjqad5" role="3cpWs9">
+              <property role="TrG5h" value="parent" />
+              <node concept="3Tqbb2" id="4LsB5Tjqad0" role="1tU5fm">
+                <ref role="ehGHo" to="yvgz:7YUYw4xHlaz" resolve="FunctionBlockContainer" />
+              </node>
+              <node concept="1PxgMI" id="4LsB5Tjqba0" role="33vP2m">
+                <property role="1BlNFB" value="true" />
+                <node concept="chp4Y" id="4LsB5Tjqbyl" role="3oSUPX">
+                  <ref role="cht4Q" to="yvgz:7YUYw4xHlaz" resolve="FunctionBlockContainer" />
+                </node>
+                <node concept="2OqwBi" id="4LsB5Tjqao0" role="1m5AlR">
+                  <node concept="1YBJjd" id="4LsB5Tjqadv" role="2Oq$k0">
+                    <ref role="1YBMHb" node="hkK7ztOYgm" resolve="functionBlock" />
+                  </node>
+                  <node concept="1mfA1w" id="4LsB5Tjqb3n" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="4LsB5Tjqbzg" role="3cqZAp">
+            <node concept="2OqwBi" id="4LsB5Tjqi2z" role="3clFbG">
+              <node concept="2OqwBi" id="4LsB5TjqbFT" role="2Oq$k0">
+                <node concept="1YBJjd" id="4LsB5Tjqbze" role="2Oq$k0">
+                  <ref role="1YBMHb" node="hkK7ztOYgm" resolve="functionBlock" />
+                </node>
+                <node concept="3Tsc0h" id="4LsB5TjqgfB" role="2OqNvi">
+                  <ref role="3TtcxE" to="yvgz:3eP8Zudp5G8" resolve="data_ports" />
+                </node>
+              </node>
+              <node concept="2es0OD" id="4LsB5TjqkKt" role="2OqNvi">
+                <node concept="1bVj0M" id="4LsB5TjqkKv" role="23t8la">
+                  <node concept="3clFbS" id="4LsB5TjqkKw" role="1bW5cS">
+                    <node concept="3cpWs8" id="4LsB5TjqmKI" role="3cqZAp">
+                      <node concept="3cpWsn" id="4LsB5TjqmKJ" role="3cpWs9">
+                        <property role="TrG5h" value="connectedPorts" />
+                        <node concept="2I9FWS" id="4LsB5TjqmKH" role="1tU5fm">
+                          <ref role="2I9WkF" to="yvgz:6po$YwiVCCi" resolve="DataPort" />
+                        </node>
+                        <node concept="2OqwBi" id="4LsB5Tjql6s" role="33vP2m">
+                          <node concept="37vLTw" id="4LsB5TjqkV7" role="2Oq$k0">
+                            <ref role="3cqZAo" node="4LsB5Tjqad5" resolve="parent" />
+                          </node>
+                          <node concept="2qgKlT" id="4LsB5TjqlmN" role="2OqNvi">
+                            <ref role="37wK5l" to="ixp9:1Fy8yZq9o69" resolve="findConnectedDataPorts" />
+                            <node concept="37vLTw" id="4LsB5Tjqltp" role="37wK5m">
+                              <ref role="3cqZAo" node="4LsB5TjqkKx" resolve="dataPort" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbJ" id="4LsB5Tjqna$" role="3cqZAp">
+                      <node concept="3clFbS" id="4LsB5TjqnaA" role="3clFbx">
+                        <node concept="2MkqsV" id="4LsB5TjqulA" role="3cqZAp">
+                          <node concept="37vLTw" id="4LsB5TjqvR5" role="1urrMF">
+                            <ref role="3cqZAo" node="4LsB5TjqkKx" resolve="dataPort" />
+                          </node>
+                          <node concept="3cpWs3" id="4LsB5Tjqvki" role="2MkJ7o">
+                            <node concept="Xl_RD" id="4LsB5Tjqvkj" role="3uHU7w">
+                              <property role="Xl_RC" value="'" />
+                            </node>
+                            <node concept="3cpWs3" id="4LsB5Tjqvkk" role="3uHU7B">
+                              <node concept="Xl_RD" id="4LsB5Tjqvkl" role="3uHU7B">
+                                <property role="Xl_RC" value="floating DataPort in parent FunctionBlockContainer '" />
+                              </node>
+                              <node concept="2OqwBi" id="4LsB5Tjqvkm" role="3uHU7w">
+                                <node concept="37vLTw" id="4LsB5Tjqvkn" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="4LsB5Tjqad5" resolve="parent" />
+                                </node>
+                                <node concept="3TrcHB" id="4LsB5Tjqvko" role="2OqNvi">
+                                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3eOVzh" id="4LsB5Tjqu8m" role="3clFbw">
+                        <node concept="3cmrfG" id="4LsB5Tjquc6" role="3uHU7w">
+                          <property role="3cmrfH" value="1" />
+                        </node>
+                        <node concept="2OqwBi" id="4LsB5TjqpoV" role="3uHU7B">
+                          <node concept="37vLTw" id="4LsB5Tjqndt" role="2Oq$k0">
+                            <ref role="3cqZAo" node="4LsB5TjqmKJ" resolve="connectedPorts" />
+                          </node>
+                          <node concept="34oBXx" id="4LsB5TjqrqP" role="2OqNvi" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="4LsB5TjqkKx" role="1bW2Oz">
+                    <property role="TrG5h" value="dataPort" />
+                    <node concept="2jxLKc" id="4LsB5TjqkKy" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="4LsB5Tjqxcx" role="3cqZAp">
+            <node concept="2OqwBi" id="4LsB5TjqzZU" role="3clFbG">
+              <node concept="2OqwBi" id="4LsB5TjqxlN" role="2Oq$k0">
+                <node concept="1YBJjd" id="4LsB5Tjqxcv" role="2Oq$k0">
+                  <ref role="1YBMHb" node="hkK7ztOYgm" resolve="functionBlock" />
+                </node>
+                <node concept="3Tsc0h" id="4LsB5TjqyjR" role="2OqNvi">
+                  <ref role="3TtcxE" to="yvgz:3eP8Zudp5Gb" resolve="trigger_ports" />
+                </node>
+              </node>
+              <node concept="2es0OD" id="4LsB5TjqBqY" role="2OqNvi">
+                <node concept="1bVj0M" id="4LsB5TjqBr0" role="23t8la">
+                  <node concept="3clFbS" id="4LsB5TjqBr1" role="1bW5cS">
+                    <node concept="3cpWs8" id="4LsB5TjqBSf" role="3cqZAp">
+                      <node concept="3cpWsn" id="4LsB5TjqBSi" role="3cpWs9">
+                        <property role="TrG5h" value="connectedPorts" />
+                        <node concept="2I9FWS" id="4LsB5TjqBSe" role="1tU5fm">
+                          <ref role="2I9WkF" to="yvgz:6jvQBgXEYiM" resolve="TriggerPort" />
+                        </node>
+                        <node concept="2OqwBi" id="4LsB5TjqCiL" role="33vP2m">
+                          <node concept="37vLTw" id="4LsB5TjqC5i" role="2Oq$k0">
+                            <ref role="3cqZAo" node="4LsB5Tjqad5" resolve="parent" />
+                          </node>
+                          <node concept="2qgKlT" id="4LsB5TjqCxJ" role="2OqNvi">
+                            <ref role="37wK5l" to="ixp9:2RC7aVK84L5" resolve="findConnectedTriggerPorts" />
+                            <node concept="37vLTw" id="4LsB5TjqCCg" role="37wK5m">
+                              <ref role="3cqZAo" node="4LsB5TjqBr2" resolve="trigPort" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbJ" id="4LsB5TjqCLQ" role="3cqZAp">
+                      <node concept="3clFbS" id="4LsB5TjqCLS" role="3clFbx">
+                        <node concept="2MkqsV" id="4LsB5TjqI9D" role="3cqZAp">
+                          <node concept="37vLTw" id="4LsB5TjqIdw" role="1urrMF">
+                            <ref role="3cqZAo" node="4LsB5TjqBr2" resolve="trigPort" />
+                          </node>
+                          <node concept="3cpWs3" id="4LsB5TjqIhs" role="2MkJ7o">
+                            <node concept="Xl_RD" id="4LsB5TjqIht" role="3uHU7w">
+                              <property role="Xl_RC" value="'" />
+                            </node>
+                            <node concept="3cpWs3" id="4LsB5TjqIhu" role="3uHU7B">
+                              <node concept="Xl_RD" id="4LsB5TjqIhv" role="3uHU7B">
+                                <property role="Xl_RC" value="floating TriggerPort in parent FunctionBlockContainer '" />
+                              </node>
+                              <node concept="2OqwBi" id="4LsB5TjqIhw" role="3uHU7w">
+                                <node concept="37vLTw" id="4LsB5TjqIhx" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="4LsB5Tjqad5" resolve="parent" />
+                                </node>
+                                <node concept="3TrcHB" id="4LsB5TjqIhy" role="2OqNvi">
+                                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3eOVzh" id="4LsB5TjqHQv" role="3clFbw">
+                        <node concept="3cmrfG" id="4LsB5TjqI0d" role="3uHU7w">
+                          <property role="3cmrfH" value="1" />
+                        </node>
+                        <node concept="2OqwBi" id="4LsB5TjqEKA" role="3uHU7B">
+                          <node concept="37vLTw" id="4LsB5TjqCQG" role="2Oq$k0">
+                            <ref role="3cqZAo" node="4LsB5TjqBSi" resolve="connectedPorts" />
+                          </node>
+                          <node concept="34oBXx" id="4LsB5TjqGBh" role="2OqNvi" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="4LsB5TjqBr2" role="1bW2Oz">
+                    <property role="TrG5h" value="trigPort" />
+                    <node concept="2jxLKc" id="4LsB5TjqBr3" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2OqwBi" id="4LsB5Tjq9t7" role="3clFbw">
+          <node concept="2OqwBi" id="4LsB5Tjq8U7" role="2Oq$k0">
+            <node concept="1YBJjd" id="4LsB5Tjq8JE" role="2Oq$k0">
+              <ref role="1YBMHb" node="hkK7ztOYgm" resolve="functionBlock" />
+            </node>
+            <node concept="1mfA1w" id="4LsB5Tjq9bj" role="2OqNvi" />
+          </node>
+          <node concept="1mIQ4w" id="4LsB5Tjqa8Y" role="2OqNvi">
+            <node concept="chp4Y" id="4LsB5TjqaaP" role="cj9EA">
+              <ref role="cht4Q" to="yvgz:7YUYw4xHlaz" resolve="FunctionBlockContainer" />
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="1YaCAy" id="hkK7ztOYgm" role="1YuTPh">
       <property role="TrG5h" value="functionBlock" />
@@ -1777,7 +1973,7 @@
                             </node>
                             <node concept="3cpWs3" id="4LsB5TjoFLA" role="3uHU7B">
                               <node concept="Xl_RD" id="4LsB5TjoE3w" role="3uHU7B">
-                                <property role="Xl_RC" value="floating port in FunctionBlockContainer '" />
+                                <property role="Xl_RC" value="floating DataPort in parent FunctionBlockContainer '" />
                               </node>
                               <node concept="2OqwBi" id="4LsB5TjoGc5" role="3uHU7w">
                                 <node concept="37vLTw" id="4LsB5TjoFP$" role="2Oq$k0">
@@ -1905,7 +2101,7 @@
                               </node>
                               <node concept="3cpWs3" id="4LsB5TjoXMK" role="3uHU7B">
                                 <node concept="Xl_RD" id="4LsB5TjoX6H" role="3uHU7B">
-                                  <property role="Xl_RC" value="floating port in DataBlockContainer '" />
+                                  <property role="Xl_RC" value="floating DataPort in parent DataBlockContainer '" />
                                 </node>
                                 <node concept="2OqwBi" id="4LsB5TjoY9d" role="3uHU7w">
                                   <node concept="37vLTw" id="4LsB5TjoXMR" role="2Oq$k0">

--- a/languages/Algorithm/models/Algorithm.typesystem.mps
+++ b/languages/Algorithm/models/Algorithm.typesystem.mps
@@ -54,6 +54,7 @@
         <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
         <child id="1068580123160" name="condition" index="3clFbw" />
         <child id="1068580123161" name="ifTrue" index="3clFbx" />
+        <child id="1206060520071" name="elsifClauses" index="3eNLev" />
       </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
@@ -67,6 +68,10 @@
       </concept>
       <concept id="1068581242869" name="jetbrains.mps.baseLanguage.structure.MinusExpression" flags="nn" index="3cpWsd" />
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1206060495898" name="jetbrains.mps.baseLanguage.structure.ElsifClause" flags="ng" index="3eNFk2">
+        <child id="1206060619838" name="condition" index="3eO9$A" />
+        <child id="1206060644605" name="statementList" index="3eOfB_" />
+      </concept>
       <concept id="1081506762703" name="jetbrains.mps.baseLanguage.structure.GreaterThanExpression" flags="nn" index="3eOSWO" />
       <concept id="1081506773034" name="jetbrains.mps.baseLanguage.structure.LessThanExpression" flags="nn" index="3eOVzh" />
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
@@ -88,6 +93,9 @@
       <concept id="1144231330558" name="jetbrains.mps.baseLanguage.structure.ForStatement" flags="nn" index="1Dw8fO">
         <child id="1144231399730" name="condition" index="1Dwp0S" />
         <child id="1144231408325" name="iteration" index="1Dwrff" />
+      </concept>
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="1350122676458893092" name="text" index="3ndbpf" />
       </concept>
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
@@ -143,8 +151,13 @@
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
         <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
       </concept>
-      <concept id="1145383075378" name="jetbrains.mps.lang.smodel.structure.SNodeListType" flags="in" index="2I9FWS" />
+      <concept id="1145383075378" name="jetbrains.mps.lang.smodel.structure.SNodeListType" flags="in" index="2I9FWS">
+        <reference id="1145383142433" name="elementConcept" index="2I9WkF" />
+      </concept>
       <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
+      <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
+        <child id="1177027386292" name="conceptArgument" index="cj9EA" />
+      </concept>
       <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI">
         <property id="1238684351431" name="asCast" index="1BlNFB" />
       </concept>
@@ -167,6 +180,14 @@
       </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="ng" index="3oM_SD">
+        <property id="155656958578482949" name="value" index="3oM_SC" />
+      </concept>
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="ng" index="1PaTwC">
+        <child id="2535923850359271783" name="elements" index="1PaTwD" />
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
@@ -1580,6 +1601,22 @@
   <node concept="18kY7G" id="hkK7ztQ45r">
     <property role="TrG5h" value="check_DataBlock" />
     <node concept="3clFbS" id="hkK7ztQ45s" role="18ibNy">
+      <node concept="3SKdUt" id="4LsB5Tjo6bm" role="3cqZAp">
+        <node concept="1PaTwC" id="4LsB5Tjo6bn" role="3ndbpf">
+          <node concept="3oM_SD" id="4LsB5Tjo6bp" role="1PaTwD">
+            <property role="3oM_SC" value="" />
+          </node>
+          <node concept="3oM_SD" id="4LsB5Tjo6c4" role="1PaTwD">
+            <property role="3oM_SC" value="unique" />
+          </node>
+          <node concept="3oM_SD" id="4LsB5Tjo6cf" role="1PaTwD">
+            <property role="3oM_SC" value="name" />
+          </node>
+          <node concept="3oM_SD" id="4LsB5TjobfC" role="1PaTwD">
+            <property role="3oM_SC" value="check" />
+          </node>
+        </node>
+      </node>
       <node concept="3cpWs8" id="hkK7ztQ4W6" role="3cqZAp">
         <node concept="3cpWsn" id="hkK7ztQ4W7" role="3cpWs9">
           <property role="TrG5h" value="dataPortNames" />
@@ -1658,6 +1695,252 @@
               <node concept="Rh6nW" id="hkK7ztQ4WD" role="1bW2Oz">
                 <property role="TrG5h" value="dataPort" />
                 <node concept="2jxLKc" id="hkK7ztQ4WE" role="1tU5fm" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="4LsB5Tjo6dE" role="3cqZAp" />
+      <node concept="3SKdUt" id="4LsB5Tjo6fk" role="3cqZAp">
+        <node concept="1PaTwC" id="4LsB5Tjo6fl" role="3ndbpf">
+          <node concept="3oM_SD" id="4LsB5Tjo6fn" role="1PaTwD">
+            <property role="3oM_SC" value="floating" />
+          </node>
+          <node concept="3oM_SD" id="4LsB5Tjo6gh" role="1PaTwD">
+            <property role="3oM_SC" value="port" />
+          </node>
+          <node concept="3oM_SD" id="4LsB5Tjobf$" role="1PaTwD">
+            <property role="3oM_SC" value="check" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbJ" id="4LsB5Tjo6mM" role="3cqZAp">
+        <node concept="3clFbS" id="4LsB5Tjo6mO" role="3clFbx">
+          <node concept="3cpWs8" id="4LsB5Tjoa8U" role="3cqZAp">
+            <node concept="3cpWsn" id="4LsB5Tjoa8X" role="3cpWs9">
+              <property role="TrG5h" value="parent" />
+              <node concept="3Tqbb2" id="4LsB5Tjoa8S" role="1tU5fm">
+                <ref role="ehGHo" to="yvgz:7YUYw4xHlaz" resolve="FunctionBlockContainer" />
+              </node>
+              <node concept="1PxgMI" id="4LsB5TjoaNK" role="33vP2m">
+                <property role="1BlNFB" value="true" />
+                <node concept="chp4Y" id="4LsB5Tjobf1" role="3oSUPX">
+                  <ref role="cht4Q" to="yvgz:7YUYw4xHlaz" resolve="FunctionBlockContainer" />
+                </node>
+                <node concept="2OqwBi" id="4LsB5TjoajT" role="1m5AlR">
+                  <node concept="1YBJjd" id="4LsB5Tjoa9o" role="2Oq$k0">
+                    <ref role="1YBMHb" node="hkK7ztQ45u" resolve="dataBlock" />
+                  </node>
+                  <node concept="1mfA1w" id="4LsB5TjoaDL" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="4LsB5TjobfJ" role="3cqZAp">
+            <node concept="2OqwBi" id="4LsB5TjodKd" role="3clFbG">
+              <node concept="2OqwBi" id="4LsB5Tjoboo" role="2Oq$k0">
+                <node concept="1YBJjd" id="4LsB5TjobfH" role="2Oq$k0">
+                  <ref role="1YBMHb" node="hkK7ztQ45u" resolve="dataBlock" />
+                </node>
+                <node concept="3Tsc0h" id="4LsB5TjobXj" role="2OqNvi">
+                  <ref role="3TtcxE" to="yvgz:6jvQBgXExiw" resolve="ports" />
+                </node>
+              </node>
+              <node concept="2es0OD" id="4LsB5Tjog3u" role="2OqNvi">
+                <node concept="1bVj0M" id="4LsB5Tjog3w" role="23t8la">
+                  <node concept="3clFbS" id="4LsB5Tjog3x" role="1bW5cS">
+                    <node concept="3cpWs8" id="4LsB5Tjoyqs" role="3cqZAp">
+                      <node concept="3cpWsn" id="4LsB5Tjoyqv" role="3cpWs9">
+                        <property role="TrG5h" value="connectedPorts" />
+                        <node concept="2I9FWS" id="4LsB5Tjoyqr" role="1tU5fm">
+                          <ref role="2I9WkF" to="yvgz:6po$YwiVCCi" resolve="DataPort" />
+                        </node>
+                        <node concept="2OqwBi" id="4LsB5TjoyRZ" role="33vP2m">
+                          <node concept="37vLTw" id="4LsB5TjoyB$" role="2Oq$k0">
+                            <ref role="3cqZAo" node="4LsB5Tjoa8X" resolve="parent" />
+                          </node>
+                          <node concept="2qgKlT" id="4LsB5Tjoz8z" role="2OqNvi">
+                            <ref role="37wK5l" to="ixp9:1Fy8yZq9o69" resolve="findConnectedDataPorts" />
+                            <node concept="37vLTw" id="4LsB5TjozgL" role="37wK5m">
+                              <ref role="3cqZAo" node="4LsB5Tjog3y" resolve="dataPort" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbJ" id="4LsB5TjozlZ" role="3cqZAp">
+                      <node concept="3clFbS" id="4LsB5Tjozm1" role="3clFbx">
+                        <node concept="2MkqsV" id="4LsB5TjoDNr" role="3cqZAp">
+                          <node concept="3cpWs3" id="4LsB5TjoH2P" role="2MkJ7o">
+                            <node concept="Xl_RD" id="4LsB5TjoH7e" role="3uHU7w">
+                              <property role="Xl_RC" value="'" />
+                            </node>
+                            <node concept="3cpWs3" id="4LsB5TjoFLA" role="3uHU7B">
+                              <node concept="Xl_RD" id="4LsB5TjoE3w" role="3uHU7B">
+                                <property role="Xl_RC" value="floating port in FunctionBlockContainer '" />
+                              </node>
+                              <node concept="2OqwBi" id="4LsB5TjoGc5" role="3uHU7w">
+                                <node concept="37vLTw" id="4LsB5TjoFP$" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="4LsB5Tjoa8X" resolve="parent" />
+                                </node>
+                                <node concept="3TrcHB" id="4LsB5TjoGCC" role="2OqNvi">
+                                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="37vLTw" id="4LsB5TjoExG" role="1urrMF">
+                            <ref role="3cqZAo" node="4LsB5Tjog3y" resolve="dataPort" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3eOVzh" id="4LsB5TjoDAa" role="3clFbw">
+                        <node concept="2OqwBi" id="4LsB5Tjo_$i" role="3uHU7B">
+                          <node concept="37vLTw" id="4LsB5TjozoQ" role="2Oq$k0">
+                            <ref role="3cqZAo" node="4LsB5Tjoyqv" resolve="connectedPorts" />
+                          </node>
+                          <node concept="34oBXx" id="4LsB5TjoBI2" role="2OqNvi" />
+                        </node>
+                        <node concept="3cmrfG" id="4LsB5TjoDy1" role="3uHU7w">
+                          <property role="3cmrfH" value="1" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="4LsB5Tjog3y" role="1bW2Oz">
+                    <property role="TrG5h" value="dataPort" />
+                    <node concept="2jxLKc" id="4LsB5Tjog3z" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2OqwBi" id="4LsB5Tjo7Ne" role="3clFbw">
+          <node concept="2OqwBi" id="4LsB5Tjo7Nf" role="2Oq$k0">
+            <node concept="1YBJjd" id="4LsB5Tjo7Ng" role="2Oq$k0">
+              <ref role="1YBMHb" node="hkK7ztQ45u" resolve="dataBlock" />
+            </node>
+            <node concept="1mfA1w" id="4LsB5Tjo7Nh" role="2OqNvi" />
+          </node>
+          <node concept="1mIQ4w" id="4LsB5Tjoa4Q" role="2OqNvi">
+            <node concept="chp4Y" id="4LsB5Tjoa6H" role="cj9EA">
+              <ref role="cht4Q" to="yvgz:7YUYw4xHlaz" resolve="FunctionBlockContainer" />
+            </node>
+          </node>
+        </node>
+        <node concept="3eNFk2" id="4LsB5TjoHlm" role="3eNLev">
+          <node concept="2OqwBi" id="4LsB5TjoIrb" role="3eO9$A">
+            <node concept="2OqwBi" id="4LsB5TjoHZD" role="2Oq$k0">
+              <node concept="1YBJjd" id="4LsB5TjoHPc" role="2Oq$k0">
+                <ref role="1YBMHb" node="hkK7ztQ45u" resolve="dataBlock" />
+              </node>
+              <node concept="1mfA1w" id="4LsB5TjoIiW" role="2OqNvi" />
+            </node>
+            <node concept="1mIQ4w" id="4LsB5TjoIT2" role="2OqNvi">
+              <node concept="chp4Y" id="4LsB5TjoITn" role="cj9EA">
+                <ref role="cht4Q" to="yvgz:5o1iPWxUm1h" resolve="DataBlockContainer" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="4LsB5TjoHlo" role="3eOfB_">
+            <node concept="3cpWs8" id="4LsB5TjoIX5" role="3cqZAp">
+              <node concept="3cpWsn" id="4LsB5TjoIX8" role="3cpWs9">
+                <property role="TrG5h" value="parent" />
+                <node concept="3Tqbb2" id="4LsB5TjoIX4" role="1tU5fm">
+                  <ref role="ehGHo" to="yvgz:5o1iPWxUm1h" resolve="DataBlockContainer" />
+                </node>
+                <node concept="1PxgMI" id="4LsB5TjoKbN" role="33vP2m">
+                  <property role="1BlNFB" value="true" />
+                  <node concept="chp4Y" id="4LsB5TjoK$4" role="3oSUPX">
+                    <ref role="cht4Q" to="yvgz:5o1iPWxUm1h" resolve="DataBlockContainer" />
+                  </node>
+                  <node concept="2OqwBi" id="4LsB5TjoJ7W" role="1m5AlR">
+                    <node concept="1YBJjd" id="4LsB5TjoIXx" role="2Oq$k0">
+                      <ref role="1YBMHb" node="hkK7ztQ45u" resolve="dataBlock" />
+                    </node>
+                    <node concept="1mfA1w" id="4LsB5TjoJPD" role="2OqNvi" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="4LsB5TjoK$D" role="3cqZAp">
+              <node concept="2OqwBi" id="4LsB5TjoNjC" role="3clFbG">
+                <node concept="2OqwBi" id="4LsB5TjoKGO" role="2Oq$k0">
+                  <node concept="1YBJjd" id="4LsB5TjoK$B" role="2Oq$k0">
+                    <ref role="1YBMHb" node="hkK7ztQ45u" resolve="dataBlock" />
+                  </node>
+                  <node concept="3Tsc0h" id="4LsB5TjoLam" role="2OqNvi">
+                    <ref role="3TtcxE" to="yvgz:6jvQBgXExiw" resolve="ports" />
+                  </node>
+                </node>
+                <node concept="2es0OD" id="4LsB5TjoQ3D" role="2OqNvi">
+                  <node concept="1bVj0M" id="4LsB5TjoQ3F" role="23t8la">
+                    <node concept="3clFbS" id="4LsB5TjoQ3G" role="1bW5cS">
+                      <node concept="3cpWs8" id="4LsB5TjoQf3" role="3cqZAp">
+                        <node concept="3cpWsn" id="4LsB5TjoQf6" role="3cpWs9">
+                          <property role="TrG5h" value="connectedPorts" />
+                          <node concept="2I9FWS" id="4LsB5TjoQf2" role="1tU5fm">
+                            <ref role="2I9WkF" to="yvgz:6po$YwiVCCi" resolve="DataPort" />
+                          </node>
+                          <node concept="2OqwBi" id="4LsB5TjoQBv" role="33vP2m">
+                            <node concept="37vLTw" id="4LsB5TjoQq0" role="2Oq$k0">
+                              <ref role="3cqZAo" node="4LsB5TjoIX8" resolve="parent" />
+                            </node>
+                            <node concept="2qgKlT" id="4LsB5TjoQQm" role="2OqNvi">
+                              <ref role="37wK5l" to="ixp9:4LsB5Tjos1C" resolve="findConnectedDataPorts" />
+                              <node concept="37vLTw" id="4LsB5TjoQYc" role="37wK5m">
+                                <ref role="3cqZAo" node="4LsB5TjoQ3H" resolve="dataPort" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbJ" id="4LsB5TjoR3q" role="3cqZAp">
+                        <node concept="3clFbS" id="4LsB5TjoR3s" role="3clFbx">
+                          <node concept="2MkqsV" id="4LsB5TjoWR0" role="3cqZAp">
+                            <node concept="3cpWs3" id="4LsB5TjoYGt" role="2MkJ7o">
+                              <node concept="Xl_RD" id="4LsB5TjoYKO" role="3uHU7w">
+                                <property role="Xl_RC" value="'" />
+                              </node>
+                              <node concept="3cpWs3" id="4LsB5TjoXMK" role="3uHU7B">
+                                <node concept="Xl_RD" id="4LsB5TjoX6H" role="3uHU7B">
+                                  <property role="Xl_RC" value="floating port in DataBlockContainer '" />
+                                </node>
+                                <node concept="2OqwBi" id="4LsB5TjoY9d" role="3uHU7w">
+                                  <node concept="37vLTw" id="4LsB5TjoXMR" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="4LsB5TjoIX8" resolve="parent" />
+                                  </node>
+                                  <node concept="3TrcHB" id="4LsB5TjoYo0" role="2OqNvi">
+                                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="37vLTw" id="4LsB5TjoYTc" role="1urrMF">
+                              <ref role="3cqZAo" node="4LsB5TjoQ3H" resolve="dataPort" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3eOVzh" id="4LsB5TjoWDh" role="3clFbw">
+                          <node concept="3cmrfG" id="4LsB5TjoWDk" role="3uHU7w">
+                            <property role="3cmrfH" value="1" />
+                          </node>
+                          <node concept="2OqwBi" id="4LsB5TjoTnJ" role="3uHU7B">
+                            <node concept="37vLTw" id="4LsB5TjoR6h" role="2Oq$k0">
+                              <ref role="3cqZAo" node="4LsB5TjoQf6" resolve="connectedPorts" />
+                            </node>
+                            <node concept="34oBXx" id="4LsB5TjoVpB" role="2OqNvi" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="4LsB5TjoQ3H" role="1bW2Oz">
+                      <property role="TrG5h" value="dataPort" />
+                      <node concept="2jxLKc" id="4LsB5TjoQ3I" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
               </node>
             </node>
           </node>

--- a/languages/Algorithm/models/Algorithm.typesystem.mps
+++ b/languages/Algorithm/models/Algorithm.typesystem.mps
@@ -801,6 +801,22 @@
   <node concept="18kY7G" id="5bwHbMcf7LG">
     <property role="TrG5h" value="check_FunctionBlockContainer" />
     <node concept="3clFbS" id="5bwHbMcf7LH" role="18ibNy">
+      <node concept="3SKdUt" id="4LsB5Tjt8BN" role="3cqZAp">
+        <node concept="1PaTwC" id="4LsB5Tjt8BO" role="3ndbpf">
+          <node concept="3oM_SD" id="4LsB5Tjt8BQ" role="1PaTwD">
+            <property role="3oM_SC" value="" />
+          </node>
+          <node concept="3oM_SD" id="4LsB5Tjt8Ee" role="1PaTwD">
+            <property role="3oM_SC" value="check" />
+          </node>
+          <node concept="3oM_SD" id="4LsB5Tjt8Eh" role="1PaTwD">
+            <property role="3oM_SC" value="duplicate" />
+          </node>
+          <node concept="3oM_SD" id="4LsB5Tjt8FH" role="1PaTwD">
+            <property role="3oM_SC" value="connectors" />
+          </node>
+        </node>
+      </node>
       <node concept="1Dw8fO" id="5bwHbMcf7M1" role="3cqZAp">
         <node concept="3cpWsn" id="5bwHbMcf7M2" role="1Duv9x">
           <property role="TrG5h" value="i" />
@@ -1055,6 +1071,178 @@
           </node>
         </node>
       </node>
+      <node concept="3clFbH" id="4LsB5Tjt8ws" role="3cqZAp" />
+      <node concept="3SKdUt" id="4LsB5Tjt83Z" role="3cqZAp">
+        <node concept="1PaTwC" id="4LsB5Tjt840" role="3ndbpf">
+          <node concept="3oM_SD" id="4LsB5Tjt841" role="1PaTwD">
+            <property role="3oM_SC" value="check" />
+          </node>
+          <node concept="3oM_SD" id="4LsB5Tjt842" role="1PaTwD">
+            <property role="3oM_SC" value="floating" />
+          </node>
+          <node concept="3oM_SD" id="4LsB5Tjt843" role="1PaTwD">
+            <property role="3oM_SC" value="ports" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbF" id="4LsB5Tjt844" role="3cqZAp">
+        <node concept="2OqwBi" id="4LsB5Tjt845" role="3clFbG">
+          <node concept="2OqwBi" id="4LsB5Tjt846" role="2Oq$k0">
+            <node concept="1YBJjd" id="4LsB5Tjt8UE" role="2Oq$k0">
+              <ref role="1YBMHb" node="5bwHbMcf7LJ" resolve="functionBlockContainer" />
+            </node>
+            <node concept="3Tsc0h" id="4LsB5Tjt9sO" role="2OqNvi">
+              <ref role="3TtcxE" to="yvgz:3eP8Zudp5G8" resolve="data_ports" />
+            </node>
+          </node>
+          <node concept="2es0OD" id="4LsB5Tjt849" role="2OqNvi">
+            <node concept="1bVj0M" id="4LsB5Tjt84a" role="23t8la">
+              <node concept="3clFbS" id="4LsB5Tjt84b" role="1bW5cS">
+                <node concept="3cpWs8" id="4LsB5Tjt84c" role="3cqZAp">
+                  <node concept="3cpWsn" id="4LsB5Tjt84d" role="3cpWs9">
+                    <property role="TrG5h" value="connectedPorts" />
+                    <node concept="2I9FWS" id="4LsB5Tjt84e" role="1tU5fm">
+                      <ref role="2I9WkF" to="yvgz:6po$YwiVCCi" resolve="DataPort" />
+                    </node>
+                    <node concept="2OqwBi" id="4LsB5Tjt84f" role="33vP2m">
+                      <node concept="1YBJjd" id="4LsB5Tjt9zq" role="2Oq$k0">
+                        <ref role="1YBMHb" node="5bwHbMcf7LJ" resolve="functionBlockContainer" />
+                      </node>
+                      <node concept="2qgKlT" id="4LsB5Tjt84h" role="2OqNvi">
+                        <ref role="37wK5l" to="ixp9:1Fy8yZq9o69" resolve="findConnectedDataPorts" />
+                        <node concept="37vLTw" id="4LsB5Tjt84i" role="37wK5m">
+                          <ref role="3cqZAo" node="4LsB5Tjt84z" resolve="dataPort" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="4LsB5Tjt84j" role="3cqZAp">
+                  <node concept="3clFbS" id="4LsB5Tjt84k" role="3clFbx">
+                    <node concept="2MkqsV" id="4LsB5Tjt84l" role="3cqZAp">
+                      <node concept="37vLTw" id="4LsB5Tjt84m" role="1urrMF">
+                        <ref role="3cqZAo" node="4LsB5Tjt84z" resolve="dataPort" />
+                      </node>
+                      <node concept="3cpWs3" id="4LsB5Tjt84n" role="2MkJ7o">
+                        <node concept="Xl_RD" id="4LsB5Tjt84o" role="3uHU7w">
+                          <property role="Xl_RC" value="'" />
+                        </node>
+                        <node concept="3cpWs3" id="4LsB5Tjt84p" role="3uHU7B">
+                          <node concept="Xl_RD" id="4LsB5Tjt84q" role="3uHU7B">
+                            <property role="Xl_RC" value="floating DataPort of FunctionBlockContainer '" />
+                          </node>
+                          <node concept="2OqwBi" id="4LsB5Tjt84r" role="3uHU7w">
+                            <node concept="1YBJjd" id="4LsB5Tjt9Wl" role="2Oq$k0">
+                              <ref role="1YBMHb" node="5bwHbMcf7LJ" resolve="functionBlockContainer" />
+                            </node>
+                            <node concept="3TrcHB" id="4LsB5Tjta1s" role="2OqNvi">
+                              <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3eOVzh" id="4LsB5Tjt84u" role="3clFbw">
+                    <node concept="3cmrfG" id="4LsB5Tjt84v" role="3uHU7w">
+                      <property role="3cmrfH" value="1" />
+                    </node>
+                    <node concept="2OqwBi" id="4LsB5Tjt84w" role="3uHU7B">
+                      <node concept="37vLTw" id="4LsB5Tjt84x" role="2Oq$k0">
+                        <ref role="3cqZAo" node="4LsB5Tjt84d" resolve="connectedPorts" />
+                      </node>
+                      <node concept="34oBXx" id="4LsB5Tjt84y" role="2OqNvi" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="Rh6nW" id="4LsB5Tjt84z" role="1bW2Oz">
+                <property role="TrG5h" value="dataPort" />
+                <node concept="2jxLKc" id="4LsB5Tjt84$" role="1tU5fm" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbF" id="4LsB5TjtaqV" role="3cqZAp">
+        <node concept="2OqwBi" id="4LsB5TjtaqW" role="3clFbG">
+          <node concept="2OqwBi" id="4LsB5TjtaqX" role="2Oq$k0">
+            <node concept="1YBJjd" id="4LsB5TjtaqY" role="2Oq$k0">
+              <ref role="1YBMHb" node="5bwHbMcf7LJ" resolve="functionBlockContainer" />
+            </node>
+            <node concept="3Tsc0h" id="4LsB5Tjtbp8" role="2OqNvi">
+              <ref role="3TtcxE" to="yvgz:3eP8Zudp5Gb" resolve="trigger_ports" />
+            </node>
+          </node>
+          <node concept="2es0OD" id="4LsB5Tjtar0" role="2OqNvi">
+            <node concept="1bVj0M" id="4LsB5Tjtar1" role="23t8la">
+              <node concept="3clFbS" id="4LsB5Tjtar2" role="1bW5cS">
+                <node concept="3cpWs8" id="4LsB5Tjtar3" role="3cqZAp">
+                  <node concept="3cpWsn" id="4LsB5Tjtar4" role="3cpWs9">
+                    <property role="TrG5h" value="connectedPorts" />
+                    <node concept="2I9FWS" id="4LsB5Tjtar5" role="1tU5fm">
+                      <ref role="2I9WkF" to="yvgz:6jvQBgXEYiM" resolve="TriggerPort" />
+                    </node>
+                    <node concept="2OqwBi" id="4LsB5Tjtar6" role="33vP2m">
+                      <node concept="1YBJjd" id="4LsB5Tjtar7" role="2Oq$k0">
+                        <ref role="1YBMHb" node="5bwHbMcf7LJ" resolve="functionBlockContainer" />
+                      </node>
+                      <node concept="2qgKlT" id="4LsB5Tjtar8" role="2OqNvi">
+                        <ref role="37wK5l" to="ixp9:2RC7aVK84L5" resolve="findConnectedTriggerPorts" />
+                        <node concept="37vLTw" id="4LsB5Tjtar9" role="37wK5m">
+                          <ref role="3cqZAo" node="4LsB5Tjtarq" resolve="trigPort" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="4LsB5Tjtara" role="3cqZAp">
+                  <node concept="3clFbS" id="4LsB5Tjtarb" role="3clFbx">
+                    <node concept="2MkqsV" id="4LsB5Tjtarc" role="3cqZAp">
+                      <node concept="37vLTw" id="4LsB5Tjtard" role="1urrMF">
+                        <ref role="3cqZAo" node="4LsB5Tjtarq" resolve="trigPort" />
+                      </node>
+                      <node concept="3cpWs3" id="4LsB5Tjtare" role="2MkJ7o">
+                        <node concept="Xl_RD" id="4LsB5Tjtarf" role="3uHU7w">
+                          <property role="Xl_RC" value="'" />
+                        </node>
+                        <node concept="3cpWs3" id="4LsB5Tjtarg" role="3uHU7B">
+                          <node concept="Xl_RD" id="4LsB5Tjtarh" role="3uHU7B">
+                            <property role="Xl_RC" value="floating TriggerPort of FunctionBlockContainer '" />
+                          </node>
+                          <node concept="2OqwBi" id="4LsB5Tjtari" role="3uHU7w">
+                            <node concept="1YBJjd" id="4LsB5Tjtarj" role="2Oq$k0">
+                              <ref role="1YBMHb" node="5bwHbMcf7LJ" resolve="functionBlockContainer" />
+                            </node>
+                            <node concept="3TrcHB" id="4LsB5Tjtark" role="2OqNvi">
+                              <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3eOVzh" id="4LsB5Tjtarl" role="3clFbw">
+                    <node concept="3cmrfG" id="4LsB5Tjtarm" role="3uHU7w">
+                      <property role="3cmrfH" value="1" />
+                    </node>
+                    <node concept="2OqwBi" id="4LsB5Tjtarn" role="3uHU7B">
+                      <node concept="37vLTw" id="4LsB5Tjtaro" role="2Oq$k0">
+                        <ref role="3cqZAo" node="4LsB5Tjtar4" resolve="connectedPorts" />
+                      </node>
+                      <node concept="34oBXx" id="4LsB5Tjtarp" role="2OqNvi" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="Rh6nW" id="4LsB5Tjtarq" role="1bW2Oz">
+                <property role="TrG5h" value="trigPort" />
+                <node concept="2jxLKc" id="4LsB5Tjtarr" role="1tU5fm" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
       <node concept="3clFbH" id="hkK7ztNjdG" role="3cqZAp" />
     </node>
     <node concept="1YaCAy" id="5bwHbMcf7LJ" role="1YuTPh">
@@ -1065,6 +1253,19 @@
   <node concept="18kY7G" id="5bwHbMch6fJ">
     <property role="TrG5h" value="check_DataBlockContainer" />
     <node concept="3clFbS" id="5bwHbMch6fK" role="18ibNy">
+      <node concept="3SKdUt" id="4LsB5Tjt8NL" role="3cqZAp">
+        <node concept="1PaTwC" id="4LsB5Tjt8NM" role="3ndbpf">
+          <node concept="3oM_SD" id="4LsB5Tjt8Q9" role="1PaTwD">
+            <property role="3oM_SC" value="check" />
+          </node>
+          <node concept="3oM_SD" id="4LsB5Tjt8Qb" role="1PaTwD">
+            <property role="3oM_SC" value="duplicate" />
+          </node>
+          <node concept="3oM_SD" id="4LsB5Tjt8Qe" role="1PaTwD">
+            <property role="3oM_SC" value="connectors" />
+          </node>
+        </node>
+      </node>
       <node concept="1Dw8fO" id="5bwHbMch6gh" role="3cqZAp">
         <node concept="3cpWsn" id="5bwHbMch6gi" role="1Duv9x">
           <property role="TrG5h" value="i" />
@@ -1189,6 +1390,99 @@
         <node concept="3uNrnE" id="5bwHbMch6h4" role="1Dwrff">
           <node concept="37vLTw" id="5bwHbMch6h5" role="2$L3a6">
             <ref role="3cqZAo" node="5bwHbMch6gi" resolve="i" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="4LsB5TjrGmw" role="3cqZAp" />
+      <node concept="3SKdUt" id="4LsB5TjrGv9" role="3cqZAp">
+        <node concept="1PaTwC" id="4LsB5TjrGva" role="3ndbpf">
+          <node concept="3oM_SD" id="4LsB5TjrGvc" role="1PaTwD">
+            <property role="3oM_SC" value="check" />
+          </node>
+          <node concept="3oM_SD" id="4LsB5TjrGwO" role="1PaTwD">
+            <property role="3oM_SC" value="floating" />
+          </node>
+          <node concept="3oM_SD" id="4LsB5TjrGwL" role="1PaTwD">
+            <property role="3oM_SC" value="ports" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbF" id="4LsB5TjrGwU" role="3cqZAp">
+        <node concept="2OqwBi" id="4LsB5TjrJ5i" role="3clFbG">
+          <node concept="2OqwBi" id="4LsB5TjrGGi" role="2Oq$k0">
+            <node concept="1YBJjd" id="4LsB5TjrGwS" role="2Oq$k0">
+              <ref role="1YBMHb" node="5bwHbMch6fM" resolve="dataBlockContainer" />
+            </node>
+            <node concept="3Tsc0h" id="4LsB5TjrHg6" role="2OqNvi">
+              <ref role="3TtcxE" to="yvgz:6jvQBgXExiw" resolve="ports" />
+            </node>
+          </node>
+          <node concept="2es0OD" id="4LsB5TjrLcn" role="2OqNvi">
+            <node concept="1bVj0M" id="4LsB5TjrLcp" role="23t8la">
+              <node concept="3clFbS" id="4LsB5TjrLcq" role="1bW5cS">
+                <node concept="3cpWs8" id="4LsB5TjrMeC" role="3cqZAp">
+                  <node concept="3cpWsn" id="4LsB5TjrMeF" role="3cpWs9">
+                    <property role="TrG5h" value="connectedPorts" />
+                    <node concept="2I9FWS" id="4LsB5TjrMeB" role="1tU5fm">
+                      <ref role="2I9WkF" to="yvgz:6po$YwiVCCi" resolve="DataPort" />
+                    </node>
+                    <node concept="2OqwBi" id="4LsB5TjrMC6" role="33vP2m">
+                      <node concept="1YBJjd" id="4LsB5TjrMnC" role="2Oq$k0">
+                        <ref role="1YBMHb" node="5bwHbMch6fM" resolve="dataBlockContainer" />
+                      </node>
+                      <node concept="2qgKlT" id="4LsB5TjrN4i" role="2OqNvi">
+                        <ref role="37wK5l" to="ixp9:4LsB5Tjos1C" resolve="findConnectedDataPorts" />
+                        <node concept="37vLTw" id="4LsB5TjrN8W" role="37wK5m">
+                          <ref role="3cqZAo" node="4LsB5TjrLcr" resolve="dataPort" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="4LsB5TjrNea" role="3cqZAp">
+                  <node concept="3clFbS" id="4LsB5TjrNec" role="3clFbx">
+                    <node concept="2MkqsV" id="4LsB5TjrSYN" role="3cqZAp">
+                      <node concept="37vLTw" id="4LsB5TjrTrN" role="1urrMF">
+                        <ref role="3cqZAo" node="4LsB5TjrLcr" resolve="dataPort" />
+                      </node>
+                      <node concept="3cpWs3" id="4LsB5TjrTav" role="2MkJ7o">
+                        <node concept="Xl_RD" id="4LsB5TjrTaw" role="3uHU7w">
+                          <property role="Xl_RC" value="'" />
+                        </node>
+                        <node concept="3cpWs3" id="4LsB5TjrTax" role="3uHU7B">
+                          <node concept="Xl_RD" id="4LsB5TjrTay" role="3uHU7B">
+                            <property role="Xl_RC" value="floating DataPort of DataBlockContainer '" />
+                          </node>
+                          <node concept="2OqwBi" id="4LsB5TjrTaz" role="3uHU7w">
+                            <node concept="1YBJjd" id="4LsB5TjrTw6" role="2Oq$k0">
+                              <ref role="1YBMHb" node="5bwHbMch6fM" resolve="dataBlockContainer" />
+                            </node>
+                            <node concept="3TrcHB" id="4LsB5TjrTa_" role="2OqNvi">
+                              <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3eOVzh" id="4LsB5TjrSLB" role="3clFbw">
+                    <node concept="3cmrfG" id="4LsB5TjrSPl" role="3uHU7w">
+                      <property role="3cmrfH" value="1" />
+                    </node>
+                    <node concept="2OqwBi" id="4LsB5TjrPrF" role="3uHU7B">
+                      <node concept="37vLTw" id="4LsB5TjrNh1" role="2Oq$k0">
+                        <ref role="3cqZAo" node="4LsB5TjrMeF" resolve="connectedPorts" />
+                      </node>
+                      <node concept="34oBXx" id="4LsB5TjrRxX" role="2OqNvi" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="Rh6nW" id="4LsB5TjrLcr" role="1bW2Oz">
+                <property role="TrG5h" value="dataPort" />
+                <node concept="2jxLKc" id="4LsB5TjrLcs" role="1tU5fm" />
+              </node>
+            </node>
           </node>
         </node>
       </node>

--- a/solutions/Algorithm.sandbox/models/Algorithm.sandbox.mps
+++ b/solutions/Algorithm.sandbox/models/Algorithm.sandbox.mps
@@ -337,13 +337,40 @@
   <node concept="1u3Uyy" id="44Cv2OMEdIf">
     <property role="TrG5h" value="testDataContainer" />
     <node concept="1OHxBB" id="44Cv2OMIBDP" role="3SlQUq">
-      <ref role="1OHxBS" node="44Cv2OMIBDG" resolve="funcContainerPort" />
+      <ref role="1OHxBS" node="44Cv2OMIBDG" resolve="funcContPortA" />
       <ref role="1OHyup" node="44Cv2OMFVOU" resolve="parent_a_port" />
     </node>
+    <node concept="1OHxBB" id="4LsB5Tjq6Qi" role="3SlQUq">
+      <ref role="1OHxBS" node="4LsB5Tjq6Pd" resolve="funcContPortB" />
+      <ref role="1OHyup" node="44Cv2OMFVP1" resolve="parent_b_port" />
+    </node>
+    <node concept="1OHxBB" id="4LsB5Tjq6Qq" role="3SlQUq">
+      <ref role="1OHxBS" node="4LsB5Tjq6PG" resolve="funcContPortC" />
+      <ref role="1OHyup" node="44Cv2OMFVPa" resolve="parent_c_port" />
+    </node>
+    <node concept="1OHxBB" id="4LsB5Tjq6Qx" role="3SlQUq">
+      <ref role="1OHxBS" node="4LsB5Tjq6Q1" resolve="funcContPortD" />
+      <ref role="1OHyup" node="5QQcZL$Ii93" resolve="pInt" />
+    </node>
     <node concept="1OHxBU" id="44Cv2OMIBDG" role="2YOnzZ">
-      <property role="TrG5h" value="funcContainerPort" />
+      <property role="TrG5h" value="funcContPortA" />
       <property role="1OHxBQ" value="6po$YwiVCCm/In" />
       <node concept="10P55v" id="44Cv2OMIBDM" role="1OHwi9" />
+    </node>
+    <node concept="1OHxBU" id="4LsB5Tjq6Pd" role="2YOnzZ">
+      <property role="TrG5h" value="funcContPortB" />
+      <property role="1OHxBQ" value="6po$YwiVCCn/Out" />
+      <node concept="10P55v" id="4LsB5Tjq6Pl" role="1OHwi9" />
+    </node>
+    <node concept="1OHxBU" id="4LsB5Tjq6PG" role="2YOnzZ">
+      <property role="TrG5h" value="funcContPortC" />
+      <property role="1OHxBQ" value="6po$YwiVCCm/In" />
+      <node concept="10P55v" id="4LsB5Tjq6PQ" role="1OHwi9" />
+    </node>
+    <node concept="1OHxBU" id="4LsB5Tjq6Q1" role="2YOnzZ">
+      <property role="TrG5h" value="funcContPortD" />
+      <property role="1OHxBQ" value="6po$YwiVCCm/In" />
+      <node concept="10P55v" id="4LsB5Tjq6Qf" role="1OHwi9" />
     </node>
     <node concept="1RU2Ge" id="44Cv2OMEdIi" role="3SlQUm">
       <property role="TrG5h" value="parentContainer" />
@@ -356,8 +383,8 @@
         <ref role="1OHxBS" node="44Cv2OMFVIU" resolve="child_port_a" />
       </node>
       <node concept="1OHxBB" id="44Cv2OMFVPw" role="1RU2Gb">
-        <ref role="1OHyup" node="44Cv2OMFVP1" resolve="parent_b_port" />
         <ref role="1OHxBS" node="44Cv2OMFVJ9" resolve="child_port_b" />
+        <ref role="1OHyup" node="44Cv2OMFVP1" resolve="parent_b_port" />
       </node>
       <node concept="1OHxBU" id="44Cv2OMFVOU" role="1ptsVk">
         <property role="TrG5h" value="parent_a_port" />
@@ -390,6 +417,10 @@
           <ref role="1OHxBS" node="44Cv2OMFVIU" resolve="child_port_a" />
           <ref role="1OHyup" node="44Cv2OMEdIA" resolve="a_port" />
         </node>
+        <node concept="1OHxBB" id="4LsB5Tjq6OL" role="1RU2Gb">
+          <ref role="1OHxBS" node="44Cv2OMFVJ9" resolve="child_port_b" />
+          <ref role="1OHyup" node="44Cv2OMEdIH" resolve="b_port" />
+        </node>
         <node concept="2_B1M0" id="44Cv2OMEdIs" role="1RU2Gd">
           <property role="TrG5h" value="a" />
           <node concept="1OHxBU" id="44Cv2OMEdIA" role="1ptsVk">
@@ -421,7 +452,7 @@
       <node concept="1OHxBU" id="5QQcZL$Ii93" role="1ptsVk">
         <property role="TrG5h" value="pInt" />
         <property role="1OHxBQ" value="6po$YwiVCCm/In" />
-        <node concept="10Oyi0" id="5QQcZL$Ii97" role="1OHwi9" />
+        <node concept="10P55v" id="4LsB5Tjq6QD" role="1OHwi9" />
       </node>
     </node>
   </node>


### PR DESCRIPTION
* This PR address the following cases of the constraint that no port should be unconnected: 
    - [x] parent connections to `DataPort`'s of a `DataBlock`
        + when parent is a `DataBlockContainer`
        + when parent is a `FunctionBlockContainer`
    - [x] parent (`FunctionBlockContainer`) connections to `DataPort`'s and `TriggerPort`'s of a `FunctionBlock`
    - [x] child connections to `DataPort`'s of a `DataBlockContainer`
    - [x] child connections to `DataPort`'s and `TriggerPort`'s of a `FunctionBlockContainer`
* This PR is an extension of PR #7 #8 to address issue #5 
* In my opinion, this can close #5 for now unless someone suggests further constraints